### PR TITLE
fix: unset local variable

### DIFF
--- a/comet/main.py
+++ b/comet/main.py
@@ -296,8 +296,8 @@ async def stream(request: Request, b64config: str, type: str, id: str):
             return {"streams": []}
 
         tasks = []
+        filtered = 0
         for torrent in torrents:
-            filtered = 0
             parsedTorrent = RTN.parse(torrent["Title"]) if indexerManagerType == "jackett" else RTN.parse(torrent["title"])
             if not "All" in config["resolutions"] and len(parsedTorrent.resolution) > 0 and parsedTorrent.resolution[0] not in config["resolutions"]:
                 filtered += 1

--- a/comet/main.py
+++ b/comet/main.py
@@ -297,6 +297,7 @@ async def stream(request: Request, b64config: str, type: str, id: str):
 
         tasks = []
         for torrent in torrents:
+            filtered = 0
             parsedTorrent = RTN.parse(torrent["Title"]) if indexerManagerType == "jackett" else RTN.parse(torrent["title"])
             if not "All" in config["resolutions"] and len(parsedTorrent.resolution) > 0 and parsedTorrent.resolution[0] not in config["resolutions"]:
                 filtered += 1


### PR DESCRIPTION
Hello,

fix UnboundLocalError : 

```
packages/starlette/routing.py", line 72, in app
2024-06-27 23:45:35 comet         |     response = await func(request)
2024-06-27 23:45:35 comet         |                ^^^^^^^^^^^^^^^^^^^
2024-06-27 23:45:35 comet         |   File "/app/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 278, in app
2024-06-27 23:45:35 comet         |     raw_response = await run_endpoint_function(
2024-06-27 23:45:35 comet         |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-27 23:45:35 comet         |   File "/app/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
2024-06-27 23:45:35 comet         |     return await dependant.call(**values)
2024-06-27 23:45:35 comet         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-27 23:45:35 comet         |   File "/app/comet/main.py", line 302, in stream
2024-06-27 23:45:35 comet         |     filtered += 1
2024-06-27 23:45:35 comet         |     ^^^^^^^^
2024-06-27 23:45:35 comet         | UnboundLocalError: cannot access local variable 'filtered' where it is not associated with a value```

Was necessary to run with jackett.