### PR TITLE
Add ability to customize result format

### DIFF
--- a/comet/api/core.py
+++ b/comet/api/core.py
@@ -39,6 +39,12 @@ web_config = {
         "4K",
         "Unknown",
     ],
+    "resultFormat": [
+        "Title",
+        "Size",
+        "Tracker",
+        "Languages",
+    ]
 }
 
 

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -23,6 +23,7 @@ from comet.utils.general import (
     get_torrent_hash,
     translate,
     get_balanced_hashes,
+    format_title
 )
 from comet.utils.logger import logger
 from comet.utils.models import database, rtn, settings
@@ -170,7 +171,7 @@ async def stream(request: Request, b64config: str, type: str, id: str):
                             results.append(
                                 {
                                     "name": f"[{debrid_extension}⚡] Comet {data['resolution'][0] if data['resolution'] != [] else 'Unknown'}",
-                                    "title": f"{data['title']}\n💾 {bytes_to_size(data['size'])} 🔎 {data['tracker'] if 'tracker' in data else '?'}{languages_str}",
+                                    "title": format_title(data['title'], data['size'], data['tracker'] if 'tracker' in data else '?', languages_str, config),
                                     "torrentTitle": data["torrent_title"]
                                     if "torrent_title" in data
                                     else None,
@@ -387,7 +388,7 @@ async def stream(request: Request, b64config: str, type: str, id: str):
                     results.append(
                         {
                             "name": f"[{debrid_extension}⚡] Comet {data['resolution'][0] if data['resolution'] != [] else 'Unknown'}",
-                            "title": f"{data['title']}\n💾 {bytes_to_size(data['size'])} 🔎 {data['tracker']}{languages_str}",
+                            "title": format_title(data['title'], data['size'], data['tracker'] if 'tracker' in data else '?', languages_str, config),
                             "torrentTitle": data["torrent_title"],
                             "torrentSize": data["torrent_size"],
                             "url": f"{request.url.scheme}://{request.url.netloc}/{b64config}/playback/{hash}/{data['index']}",

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -13,7 +13,6 @@ from RTN import Torrent, sort_torrents
 from comet.debrid.manager import getDebrid
 from comet.utils.general import (
     get_language_emoji,
-    bytes_to_size,
     config_check,
     get_debrid_extension,
     get_indexer_manager,

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -60,7 +60,7 @@
                 height: 1em;
                 vertical-align: middle;
             }
-            
+
             .form-container {
                 background-color: #1a1d20;
                 padding: 2rem;
@@ -528,6 +528,15 @@
             </div>
 
             <div class="form-item">
+                <sl-select id="titleFormat" value="titleIncludeTorrentTitle titleIncludeSize titleIncludeTrackers titleIncludeLanguages" multiple label="Title Format" placeholder="Select what to show in result title" max-options-visible=4>
+                  <sl-option value="titleIncludeTorrentTitle">Torrent Title</sl-option>
+                  <sl-option value="titleIncludeSize">Size</sl-option>
+                  <sl-option value="titleIncludeTrackers">Trackers</sl-option>
+                  <sl-option value="titleIncludeLanguages">Languages</sl-option>
+                </sl-select>
+            </div>
+
+            <div class="form-item">
                 <sl-input id="debridStreamProxyPassword" label="Debrid Stream Proxy Password" placeholder="{% if not proxyDebridStream %}Configuration required, see docs{% else %}Enter password{% endif %}" help-text="Debrid Stream Proxying allows you to use your Debrid Service from multiple IPs at same time!" {% if not proxyDebridStream %} disabled {% endif %}></sl-input>
             </div>
 
@@ -543,17 +552,17 @@
 
             <div class="form-item">
                 <label for="debridService">
-                    Debrid API Key - 
+                    Debrid API Key -
                     <a id="apiKeyLink" href="https://real-debrid.com/apitoken" target="_blank">Get It Here</a>
                 </label>
                 <sl-input id="debridApiKey" placeholder="Enter API key"></sl-input>
             </div>
-            
+
             <script>
                 document.getElementById("debridService").addEventListener("sl-change", function(event) {
                     const selectedService = event.target.value;
                     const apiKeyLink = document.getElementById("apiKeyLink");
-            
+
                     if (selectedService === "realdebrid") {
                         apiKeyLink.href = "https://real-debrid.com/apitoken";
                     } else if (selectedService === "alldebrid") {
@@ -580,7 +589,7 @@
                     <sl-icon slot="icon" name="clipboard2-check"></sl-icon>
                     <strong>The Stremio addon link has been automatically copied.</strong>
                 </sl-alert>
-                
+
                 <script type="module">
                     let defaultLanguages = [];
                     let defaultResolutions = [];
@@ -635,16 +644,18 @@
                         const resolutions = Array.from(document.getElementById("resolutions").selectedOptions).map(option => option.value);
                         const maxResults = document.getElementById("maxResults").value;
                         const maxSize = document.getElementById("maxSize").value;
+                        const titleFormat = Array.from(document.getElementById("titleFormat").selectedOptions).map(option => option.value);
                         const debridService = document.getElementById("debridService").value;
                         const debridApiKey = document.getElementById("debridApiKey").value;
                         const debridStreamProxyPassword = document.getElementById("debridStreamProxyPassword").value;
                         const selectedLanguages = languages.length === defaultLanguages.length && languages.every((val, index) => val === defaultLanguages[index]) ? ["All"] : languages;
                         const selectedResolutions = resolutions.length === defaultResolutions.length && resolutions.every((val, index) => val === defaultResolutions[index]) ? ["All"] : resolutions;
-                        
+
                         return {
                             indexers: indexers,
                             maxResults: parseInt(maxResults),
                             maxSize: parseFloat(maxSize * 1073741824),
+                            titleFormat: titleFormat,
                             resolutions: selectedResolutions,
                             languages: selectedLanguages,
                             debridService: debridService,
@@ -684,24 +695,25 @@
                         if (url.split("/").length < 5) {
                             console.log("no previous settings"); return null;
                         }
-                    	const settingsString =  url.split("/")[3];
+                        const settingsString =  url.split("/")[3];
                         if (typeof settingsString === "undefined") {
                             console.log("can't fetch previous settings", settingsString)
-                            return null; 
+                            return null;
                         }
                         const settingsJson = atob(settingsString);
                         return JSON.parse(settingsJson);
                     }
 
-                    function populateFormFromSettings(settings) {        
+                    function populateFormFromSettings(settings) {
                         document.getElementById("maxResults").value = settings.maxResults;
                         document.getElementById("maxSize").value = settings.maxSize / 1073741824; // Convert back from bytes to GB
+                        document.getElementById("titleFormat").value = settings.titleFormat;
                         document.getElementById("debridService").value = settings.debridService;
                         document.getElementById("debridApiKey").value = settings.debridApiKey;
                         document.getElementById("debridStreamProxyPassword").value = settings.debridStreamProxyPassword;
                         document.getElementById("indexers").value = settings.indexers;
                         if (settings.languages != "All")
-                            document.getElementById("languages").value = settings.languages; 
+                            document.getElementById("languages").value = settings.languages;
                         if (settings.resolutions != "All")
                             document.getElementById("resolutions").value = settings.resolutions;
                     }

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -75,6 +75,10 @@
                 margin-bottom: 0.75rem;
             }
 
+            sl-details {
+                margin-bottom: 0.75rem;
+            }
+
             .centered-item {
                 display: flex;
                 justify-content: center;
@@ -528,15 +532,6 @@
             </div>
 
             <div class="form-item">
-                <sl-select id="titleFormat" value="titleIncludeTorrentTitle titleIncludeSize titleIncludeTrackers titleIncludeLanguages" multiple label="Title Format" placeholder="Select what to show in result title" max-options-visible=4>
-                  <sl-option value="titleIncludeTorrentTitle">Torrent Title</sl-option>
-                  <sl-option value="titleIncludeSize">Size</sl-option>
-                  <sl-option value="titleIncludeTrackers">Trackers</sl-option>
-                  <sl-option value="titleIncludeLanguages">Languages</sl-option>
-                </sl-select>
-            </div>
-
-            <div class="form-item">
                 <sl-input id="debridStreamProxyPassword" label="Debrid Stream Proxy Password" placeholder="{% if not proxyDebridStream %}Configuration required, see docs{% else %}Enter password{% endif %}" help-text="Debrid Stream Proxying allows you to use your Debrid Service from multiple IPs at same time!" {% if not proxyDebridStream %} disabled {% endif %}></sl-input>
             </div>
 
@@ -557,6 +552,13 @@
                 </label>
                 <sl-input id="debridApiKey" placeholder="Enter API key"></sl-input>
             </div>
+
+            <sl-details summary="Advanced Settings">
+                <div class="form-item">
+                    <sl-select id="resultFormat" multiple label="Result Format" placeholder="Select what to show in result title" hoist max-options-visible=4>
+                    </sl-select>
+                </div>
+            </sl-details>
 
             <script>
                 document.getElementById("debridService").addEventListener("sl-change", function(event) {
@@ -593,6 +595,7 @@
                 <script type="module">
                     let defaultLanguages = [];
                     let defaultResolutions = [];
+                    let defaultResultFormat = [];
 
                     document.addEventListener("DOMContentLoaded", async () => {
                         await Promise.allSettled([
@@ -608,9 +611,11 @@
                         populateSelect("indexers", webConfig.indexers);
                         populateSelect("languages", webConfig.languages);
                         populateSelect("resolutions", webConfig.resolutions);
+                        populateSelect("resultFormat", webConfig.resultFormat);
                         document.body.classList.add("ready");
                         defaultLanguages = webConfig.languages;
                         defaultResolutions = webConfig.resolutions;
+                        defaultResultFormat = webConfig.resultFormat;
 
                         // try populate the form from previous settings
                         try {
@@ -644,18 +649,19 @@
                         const resolutions = Array.from(document.getElementById("resolutions").selectedOptions).map(option => option.value);
                         const maxResults = document.getElementById("maxResults").value;
                         const maxSize = document.getElementById("maxSize").value;
-                        const titleFormat = Array.from(document.getElementById("titleFormat").selectedOptions).map(option => option.value);
+                        const resultFormat = Array.from(document.getElementById("resultFormat").selectedOptions).map(option => option.value);
                         const debridService = document.getElementById("debridService").value;
                         const debridApiKey = document.getElementById("debridApiKey").value;
                         const debridStreamProxyPassword = document.getElementById("debridStreamProxyPassword").value;
                         const selectedLanguages = languages.length === defaultLanguages.length && languages.every((val, index) => val === defaultLanguages[index]) ? ["All"] : languages;
                         const selectedResolutions = resolutions.length === defaultResolutions.length && resolutions.every((val, index) => val === defaultResolutions[index]) ? ["All"] : resolutions;
+                        const selectedResultFormat = resultFormat.length === defaultResultFormat.length && resultFormat.every((val, index) => val === defaultResultFormat[index]) ? ["All"] : resultFormat;
 
                         return {
                             indexers: indexers,
                             maxResults: parseInt(maxResults),
                             maxSize: parseFloat(maxSize * 1073741824),
-                            titleFormat: titleFormat,
+                            resultFormat: selectedResultFormat,
                             resolutions: selectedResolutions,
                             languages: selectedLanguages,
                             debridService: debridService,
@@ -707,7 +713,6 @@
                     function populateFormFromSettings(settings) {
                         document.getElementById("maxResults").value = settings.maxResults;
                         document.getElementById("maxSize").value = settings.maxSize / 1073741824; // Convert back from bytes to GB
-                        document.getElementById("titleFormat").value = settings.titleFormat;
                         document.getElementById("debridService").value = settings.debridService;
                         document.getElementById("debridApiKey").value = settings.debridApiKey;
                         document.getElementById("debridStreamProxyPassword").value = settings.debridStreamProxyPassword;
@@ -716,6 +721,8 @@
                             document.getElementById("languages").value = settings.languages;
                         if (settings.resolutions != "All")
                             document.getElementById("resolutions").value = settings.resolutions;
+                        if (settings.resultFormat != "All")
+                            document.getElementById("resultFormat").value = settings.resultFormat;
                     }
 
                 </script>

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -552,4 +552,7 @@ def format_title(torrent_title: str, torrent_size: int, torrent_tracker: str, to
         title += f"🔎 {torrent_tracker}"
     if "Languages" in config["resultFormat"] or "All" in config["resultFormat"]:
         title += f"{torrent_languages}"
+    if title == "":
+        # Without this, Streamio shows SD as the result, which is confusing
+        title = "Empty result format configuration"
     return title

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -540,3 +540,16 @@ def get_balanced_hashes(hashes: dict, config: dict):
             missing_hashes -= len(available_hashes)
 
     return balanced_hashes
+
+
+def format_title(torrent_title: str, torrent_size: int, torrent_tracker: str, torrent_languages: str, config: dict):
+    title = ""
+    if "titleIncludeTorrentTitle" in config["titleFormat"]:
+        title += f"{torrent_title}\n"
+    if "titleIncludeSize" in config["titleFormat"]:
+        title += f"💾 {bytes_to_size(torrent_size)} "
+    if "titleIncludeTracker" in config["titleFormat"]:
+        title += f"🔎 {torrent_tracker}"
+    if "titleIncludeLanguages" in config["titleFormat"]:
+        title += f"{torrent_languages}"
+    return title

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -544,12 +544,12 @@ def get_balanced_hashes(hashes: dict, config: dict):
 
 def format_title(torrent_title: str, torrent_size: int, torrent_tracker: str, torrent_languages: str, config: dict):
     title = ""
-    if "titleIncludeTorrentTitle" in config["titleFormat"]:
+    if "Title" in config["resultFormat"] or "All" in config["resultFormat"]:
         title += f"{torrent_title}\n"
-    if "titleIncludeSize" in config["titleFormat"]:
+    if "Size" in config["resultFormat"] or "All" in config["resultFormat"]:
         title += f"💾 {bytes_to_size(torrent_size)} "
-    if "titleIncludeTracker" in config["titleFormat"]:
+    if "Tracker" in config["resultFormat"] or "All" in config["resultFormat"]:
         title += f"🔎 {torrent_tracker}"
-    if "titleIncludeLanguages" in config["titleFormat"]:
+    if "Languages" in config["resultFormat"] or "All" in config["resultFormat"]:
         title += f"{torrent_languages}"
     return title

--- a/comet/utils/models.py
+++ b/comet/utils/models.py
@@ -40,7 +40,7 @@ class ConfigModel(BaseModel):
     indexers: List[str]
     languages: Optional[List[str]] = ["All"]
     resolutions: Optional[List[str]] = ["All"]
-    titleFormat: Optional[List[str]] = ["titleIncludeTorrentTitle", "titleIncludeSize", "titleIncludeTracker", "titleIncludeLanguages"]
+    resultFormat: Optional[List[str]] = ["All"]
     maxResults: Optional[int] = 0
     maxSize: Optional[float] = 0
     debridService: str

--- a/comet/utils/models.py
+++ b/comet/utils/models.py
@@ -40,6 +40,7 @@ class ConfigModel(BaseModel):
     indexers: List[str]
     languages: Optional[List[str]] = ["All"]
     resolutions: Optional[List[str]] = ["All"]
+    titleFormat: Optional[List[str]] = ["titleIncludeTorrentTitle", "titleIncludeSize", "titleIncludeTracker", "titleIncludeLanguages"]
     maxResults: Optional[int] = 0
     maxSize: Optional[float] = 0
     debridService: str


### PR DESCRIPTION
Hello 👋

This PR adds the ability for the user to customize the format of the result being shown in Stremio. I do this mainly to hide the tracker field, since sometimes people prefer to not know where their videos are coming from 😉 But the PR is generalized enough to show/hide any field currently being used in the Result (TItle/Tracker/Size/Languages). Here are a few screenshots:

Config screen:

![image](https://github.com/user-attachments/assets/7ca3daa9-8898-470b-812e-d7d0b1a18be5)

I hide this config under the Advanced section, since most people would not need to configure it.

When it's expanded, it looks like this:

![image](https://github.com/user-attachments/assets/ce043bde-a159-46ba-a734-f73f6b4bc693)

Here's an example of what the result looks like, omitting the Tracker field:

![image](https://github.com/user-attachments/assets/5a474794-371b-4f5e-9c3a-402c53fd5481)
