### PR TITLE
Add metadata to result title

### DIFF
--- a/comet/api/core.py
+++ b/comet/api/core.py
@@ -39,12 +39,7 @@ web_config = {
         "4K",
         "Unknown",
     ],
-    "resultFormat": [
-        "Title",
-        "Size",
-        "Tracker",
-        "Languages",
-    ]
+    "resultFormat": ["Title", "Metadata", "Size", "Tracker", "Languages"],
 }
 
 

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -151,32 +151,20 @@ async def stream(request: Request, b64config: str, type: str, id: str):
                     for resolution, hash_list in balanced_hashes.items():
                         if hash in hash_list:
                             data = hash_data["data"]
-                            languages = data["language"]
-                            formatted_languages = (
-                                "/".join(
-                                    get_language_emoji(language)
-                                    for language in languages
-                                )
-                                if languages
-                                else get_language_emoji("multi_audio")
-                                if data["is_multi_audio"]
-                                else None
-                            )
-                            languages_str = (
-                                "\n" + formatted_languages
-                                if formatted_languages
-                                else ""
-                            )
                             results.append(
                                 {
                                     "name": f"[{debrid_extension}⚡] Comet {data['resolution'][0] if data['resolution'] != [] else 'Unknown'}",
-                                    "title": format_title(data['title'], data['size'], data['tracker'] if 'tracker' in data else '?', languages_str, config),
-                                    "torrentTitle": data["torrent_title"]
-                                    if "torrent_title" in data
-                                    else None,
-                                    "torrentSize": data["torrent_size"]
-                                    if "torrent_size" in data
-                                    else None,
+                                    "title": format_title(data, config),
+                                    "torrentTitle": (
+                                        data["torrent_title"]
+                                        if "torrent_title" in data
+                                        else None
+                                    ),
+                                    "torrentSize": (
+                                        data["torrent_size"]
+                                        if "torrent_size" in data
+                                        else None
+                                    ),
                                     "url": f"{request.url.scheme}://{request.url.netloc}/{b64config}/playback/{hash}/{data['index']}",
                                 }
                             )
@@ -373,21 +361,10 @@ async def stream(request: Request, b64config: str, type: str, id: str):
             for resolution, hash_list in balanced_hashes.items():
                 if hash in hash_list:
                     data = hash_data["data"]
-                    languages = data["language"]
-                    formatted_languages = (
-                        "/".join(get_language_emoji(language) for language in languages)
-                        if languages
-                        else get_language_emoji("multi_audio")
-                        if data["is_multi_audio"]
-                        else None
-                    )
-                    languages_str = (
-                        "\n" + formatted_languages if formatted_languages else ""
-                    )
                     results.append(
                         {
                             "name": f"[{debrid_extension}⚡] Comet {data['resolution'][0] if data['resolution'] != [] else 'Unknown'}",
-                            "title": format_title(data['title'], data['size'], data['tracker'] if 'tracker' in data else '?', languages_str, config),
+                            "title": format_title(data, config),
                             "torrentTitle": data["torrent_title"],
                             "torrentSize": data["torrent_size"],
                             "url": f"{request.url.scheme}://{request.url.netloc}/{b64config}/playback/{hash}/{data['index']}",

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -555,7 +555,7 @@
 
             <sl-details summary="Advanced Settings">
                 <div class="form-item">
-                    <sl-select id="resultFormat" multiple label="Result Format" placeholder="Select what to show in result title" hoist max-options-visible=4>
+                    <sl-select id="resultFormat" multiple label="Result Format" placeholder="Select what to show in result title" hoist max-options-visible=10>
                     </sl-select>
                 </div>
             </sl-details>

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -542,16 +542,49 @@ def get_balanced_hashes(hashes: dict, config: dict):
     return balanced_hashes
 
 
-def format_title(torrent_title: str, torrent_size: int, torrent_tracker: str, torrent_languages: str, config: dict):
+def format_metadata(data: dict):
+    extras = []
+    if data["hdr"] != "":
+        extras.append(data["hdr"] if data["hdr"] != "DV" else "Dolby Vision")
+    if data["remux"]:
+        extras.append("Remux")
+    if data["proper"]:
+        extras.append("Proper")
+    if data["repack"]:
+        extras.append("Repack")
+    if data["upscaled"]:
+        extras.append("Upscaled")
+    if data["remastered"]:
+        extras.append("Remastered")
+    if data["directorsCut"]:
+        extras.append("Director's Cut")
+    if data["extended"]:
+        extras.append("Extended")
+    return " | ".join(extras)
+
+
+def format_title(data: dict, config: dict):
     title = ""
+    logger.info(config)
     if "Title" in config["resultFormat"] or "All" in config["resultFormat"]:
-        title += f"{torrent_title}\n"
+        title += f"{data['title']}\n"
+    if "Metadata" in config["resultFormat"] or "All" in config["resultFormat"]:
+        metadata = format_metadata(data)
+        if metadata != "":
+            title += f"💿 {metadata}\n"
     if "Size" in config["resultFormat"] or "All" in config["resultFormat"]:
-        title += f"💾 {bytes_to_size(torrent_size)} "
+        title += f"💾 {bytes_to_size(data['size'])} "
     if "Tracker" in config["resultFormat"] or "All" in config["resultFormat"]:
-        title += f"🔎 {torrent_tracker}"
+        title += f"🔎 {data['tracker'] if 'tracker' in data else '?'}"
     if "Languages" in config["resultFormat"] or "All" in config["resultFormat"]:
-        title += f"{torrent_languages}"
+        languages = data["language"]
+        formatted_languages = (
+            "/".join(get_language_emoji(language) for language in languages)
+            if languages
+            else get_language_emoji("multi_audio") if data["is_multi_audio"] else None
+        )
+        languages_str = "\n" + formatted_languages if formatted_languages else ""
+        title += f"{languages_str}"
     if title == "":
         # Without this, Streamio shows SD as the result, which is confusing
         title = "Empty result format configuration"


### PR DESCRIPTION
Continuation of my earlier PR, this time we add some metadata to the result so that's easier for the user to glance and choose the correct stream (especially in the desktop version, since the title is usually truncated on smaller screens). See the following screenshot as example:

![image](https://github.com/user-attachments/assets/32bb1067-5429-4ad1-87b3-6dd73239e452)

When there's no extra metadata to display, the line is not shown:

![image](https://github.com/user-attachments/assets/d394a9a0-b6b2-462b-81bf-95c1c16b8997)

This is simply using the result parsed by RTN (excellent library btw). I also added metadata as an option to turn on/off in the result format (in case users don't want to see this information), and also refactored some code to be less duplicated.