### PR TITLE
feat(debrid): add support for stremthru

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -27,4 +27,5 @@ PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE=realdebrid # if you want your users w
 PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY=CHANGE_ME # if you want your users who use the Debrid Stream Proxy not to have to specify Debrid information, but to use the default one instead
 TITLE_MATCH_CHECK=True # disable if you only use Torrentio / MediaFusion and are sure you're only scraping good titles, for example (keep it True if Zilean is enabled)
 REMOVE_ADULT_CONTENT=False # detect and remove adult content
+STREMTHRU_DEFAULT_URL=None # if you want your users to use StremThru without having to specify it
 CUSTOM_HEADER_HTML=None # only set it if you know what it is

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Direct Torrent supported (do not specify a Debrid API Key on the configuration page (webui) to activate it - it will use the cached results of other users using debrid service)
 - [Kitsu](https://kitsu.io/) support (anime)
 - Adult Content Filter
+- [StremThru](https://github.com/MunifTanjim/stremthru) support
 
 # Installation
 To customize your Comet experience to suit your needs, please first take a look at all the [environment variables](https://github.com/g0ldyy/comet/blob/main/.env-sample)!

--- a/comet/api/core.py
+++ b/comet/api/core.py
@@ -59,7 +59,7 @@ async def manifest(b64config: str = None):
     if not config:
         config = {"debridService": None}
 
-    debrid_extension = get_debrid_extension(config["debridService"])
+    debrid_extension = get_debrid_extension(config["debridService"], config["debridApiKey"])
 
     return {
         "id": settings.ADDON_ID,

--- a/comet/api/core.py
+++ b/comet/api/core.py
@@ -47,6 +47,7 @@ async def configure(request: Request):
             "webConfig": web_config,
             "indexerManager": settings.INDEXER_MANAGER_TYPE,
             "proxyDebridStream": settings.PROXY_DEBRID_STREAM,
+            "stremthruDefaultUrl": settings.STREMTHRU_DEFAULT_URL or "",
         },
     )
 

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -484,13 +484,17 @@ async def stream(
         for resolution in balanced_hashes:
             for hash in balanced_hashes[resolution]:
                 data = sorted_ranked_files[hash]["data"]
+                index = data['index']
+                if index == -1:
+                    index = data['title']
+                url = f"{request.url.scheme}://{request.url.netloc}/{b64config}/playback/{hash}/{index}"
                 results.append(
                     {
                         "name": f"[{debrid_extension}⚡] Comet {data['resolution']}",
                         "description": format_title(data, config),
                         "torrentTitle": data["torrent_title"],
                         "torrentSize": data["torrent_size"],
-                        "url": f"{request.url.scheme}://{request.url.netloc}/{b64config}/playback/{hash}/{data['index']}",
+                        "url": url,
                         "behaviorHints": {
                             "filename": data["raw_title"],
                             "bingeGroup": "comet|" + hash,

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -235,7 +235,7 @@ async def stream(
                         )
                     else:
                         the_stream["infoHash"] = hash
-                        index = data["index"]
+                        index = str(data["index"])
                         the_stream["fileIdx"] = (
                             1 if "|" in index else int(index)
                         )  # 1 because for Premiumize it's impossible to get the file index

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -411,6 +411,7 @@ async def stream(
             season,
             episode,
             kitsu,
+            video_id=full_id,
         )
 
         ranked_files = set()

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -465,7 +465,7 @@ async def stream(
 
         logger.info(f"Results have been cached for {log_name}")
 
-        debrid_extension = get_debrid_extension(config["debridService"])
+        debrid_extension = get_debrid_extension(config["debridService"], config["debridApiKey"])
 
         balanced_hashes = get_balanced_hashes(sorted_ranked_files, config)
 

--- a/comet/debrid/alldebrid.py
+++ b/comet/debrid/alldebrid.py
@@ -44,7 +44,7 @@ class AllDebrid:
             )
 
     async def get_files(
-        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool
+        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool, **kwargs
     ):
         chunk_size = 500
         chunks = [

--- a/comet/debrid/debridlink.py
+++ b/comet/debrid/debridlink.py
@@ -48,7 +48,7 @@ class DebridLink:
         return responses
 
     async def get_files(
-        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool
+        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool, **kwargs
     ):
         chunk_size = 10
         chunks = [

--- a/comet/debrid/manager.py
+++ b/comet/debrid/manager.py
@@ -20,6 +20,7 @@ def getDebrid(session: aiohttp.ClientSession, config: dict, ip: str):
             url=config["stremthruUrl"],
             debrid_service=debrid_service,
             token=debrid_api_key,
+            ip=ip,
         )
 
     if debrid_service == "realdebrid":

--- a/comet/debrid/manager.py
+++ b/comet/debrid/manager.py
@@ -1,15 +1,27 @@
 import aiohttp
 
+from comet.utils.config import should_use_stremthru
+
 from .realdebrid import RealDebrid
 from .alldebrid import AllDebrid
 from .premiumize import Premiumize
 from .torbox import TorBox
 from .debridlink import DebridLink
+from .stremthru import StremThru
 
 
 def getDebrid(session: aiohttp.ClientSession, config: dict, ip: str):
     debrid_service = config["debridService"]
     debrid_api_key = config["debridApiKey"]
+
+    if should_use_stremthru(config):
+        return StremThru(
+            session=session,
+            url=config["stremthruUrl"],
+            debrid_service=debrid_service,
+            token=debrid_api_key,
+        )
+
     if debrid_service == "realdebrid":
         return RealDebrid(session, debrid_api_key, ip)
     elif debrid_service == "alldebrid":

--- a/comet/debrid/premiumize.py
+++ b/comet/debrid/premiumize.py
@@ -49,7 +49,7 @@ class Premiumize:
             )
 
     async def get_files(
-        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool
+        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool, **kwargs
     ):
         chunk_size = 100
         chunks = [

--- a/comet/debrid/realdebrid.py
+++ b/comet/debrid/realdebrid.py
@@ -42,7 +42,7 @@ class RealDebrid:
             )
 
     async def get_files(
-        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool
+        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool, **kwargs
     ):
         chunk_size = 100
         chunks = [

--- a/comet/debrid/stremthru.py
+++ b/comet/debrid/stremthru.py
@@ -1,0 +1,174 @@
+import asyncio
+from typing import Optional
+
+import aiohttp
+from RTN import parse
+
+from comet.utils.general import is_video
+from comet.utils.logger import logger
+
+
+class StremThru:
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        token: str,
+        debrid_service: str,
+    ):
+        if not self.is_supported_store(debrid_service):
+            raise ValueError(f"unsupported store: {debrid_service}")
+
+        if debrid_service == "stremthru":
+            session.headers["Proxy-Authorization"] = f"Basic {token}"
+        else:
+            session.headers["X-StremThru-Store-Name"] = debrid_service
+            session.headers["X-StremThru-Store-Authorization"] = f"Bearer {token}"
+
+        session.headers["User-Agent"] = "comet"
+
+        self.session = session
+        self.base_url = f"{url}/v0/store"
+        self.name = f"StremThru[{debrid_service}]" if debrid_service else "StremThru"
+
+    @staticmethod
+    def is_supported_store(name: Optional[str]):
+        return (
+            name == "stremthru"
+            or name == "alldebrid"
+            or name == "debridlink"
+            or name == "premiumize"
+            or name == "realdebrid"
+            or name == "torbox"
+        )
+
+    async def check_premium(self):
+        try:
+            user = await self.session.get(f"{self.base_url}/user")
+            user = await user.json()
+            return user["data"]["subscription_status"] == "premium"
+        except Exception as e:
+            logger.warning(
+                f"Exception while checking premium status on {self.name}: {e}"
+            )
+
+        return False
+
+    async def get_instant(self, magnets: list):
+        try:
+            magnet = await self.session.get(
+                f"{self.base_url}/magnets/check?magnet={','.join(magnets)}"
+            )
+            return await magnet.json()
+        except Exception as e:
+            logger.warning(
+                f"Exception while checking hash instant availability on {self.name}: {e}"
+            )
+
+    async def get_files(
+        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool
+    ):
+        chunk_size = 25
+        chunks = [
+            torrent_hashes[i : i + chunk_size]
+            for i in range(0, len(torrent_hashes), chunk_size)
+        ]
+
+        tasks = []
+        for chunk in chunks:
+            tasks.append(self.get_instant(chunk))
+
+        responses = await asyncio.gather(*tasks)
+
+        availability = [
+            response["data"]["items"]
+            for response in responses
+            if response and "data" in response
+        ]
+
+        files = {}
+
+        if type == "series":
+            for magnets in availability:
+                for magnet in magnets:
+                    if magnet["status"] != "cached":
+                        continue
+
+                    for file in magnet["files"]:
+                        filename = file["name"]
+
+                        if not is_video(filename) or "sample" in filename:
+                            continue
+
+                        filename_parsed = parse(filename)
+
+                        if episode not in filename_parsed.episodes:
+                            continue
+
+                        if kitsu:
+                            if filename_parsed.seasons:
+                                continue
+                        else:
+                            if season not in filename_parsed.seasons:
+                                continue
+
+                        files[magnet["hash"]] = {
+                            "index": file["index"],
+                            "title": filename,
+                            "size": file["size"],
+                        }
+
+                        break
+        else:
+            for magnets in availability:
+                for magnet in magnets:
+                    if magnet["status"] != "cached":
+                        continue
+
+                    for file in magnet["files"]:
+                        filename = file["name"]
+
+                        if not is_video(filename) or "sample" in filename:
+                            continue
+
+                        files[magnet["hash"]] = {
+                            "index": file["index"],
+                            "title": filename,
+                            "size": file["size"],
+                        }
+
+                        break
+
+        return files
+
+    async def generate_download_link(self, hash: str, index: str):
+        try:
+            magnet = await self.session.post(
+                f"{self.base_url}/magnets",
+                json={"magnet": f"magnet:?xt=urn:btih:{hash}"},
+            )
+            magnet = await magnet.json()
+
+            file = next(
+                (
+                    file
+                    for file in magnet["data"]["files"]
+                    if file["index"] == int(index)
+                ),
+                None,
+            )
+
+            if not file:
+                return
+
+            link = await self.session.post(
+                f"{self.base_url}/link/generate",
+                json={"link": file["link"]},
+            )
+            link = await link.json()
+
+            return link["data"]["link"]
+        except Exception as e:
+            logger.warning(
+                f"Exception while getting download link from {self.name} for {hash}|{index}: {e}"
+            )

--- a/comet/debrid/stremthru.py
+++ b/comet/debrid/stremthru.py
@@ -15,6 +15,7 @@ class StremThru:
         url: str,
         token: str,
         debrid_service: str,
+        ip: str,
     ):
         if not self.is_supported_store(debrid_service):
             raise ValueError(f"unsupported store: {debrid_service}")
@@ -30,6 +31,7 @@ class StremThru:
         self.session = session
         self.base_url = f"{url}/v0/store"
         self.name = f"StremThru[{debrid_service}]" if debrid_service else "StremThru"
+        self.client_ip = ip
 
     @staticmethod
     def is_supported_store(name: Optional[str]):
@@ -44,7 +46,9 @@ class StremThru:
 
     async def check_premium(self):
         try:
-            user = await self.session.get(f"{self.base_url}/user")
+            user = await self.session.get(
+                f"{self.base_url}/user?client_ip={self.client_ip}"
+            )
             user = await user.json()
             return user["data"]["subscription_status"] == "premium"
         except Exception as e:
@@ -57,7 +61,7 @@ class StremThru:
     async def get_instant(self, magnets: list):
         try:
             magnet = await self.session.get(
-                f"{self.base_url}/magnets/check?magnet={','.join(magnets)}"
+                f"{self.base_url}/magnets/check?magnet={','.join(magnets)}&client_ip={self.client_ip}"
             )
             return await magnet.json()
         except Exception as e:
@@ -144,7 +148,7 @@ class StremThru:
     async def generate_download_link(self, hash: str, index: str):
         try:
             magnet = await self.session.post(
-                f"{self.base_url}/magnets",
+                f"{self.base_url}/magnets?client_ip={self.client_ip}",
                 json={"magnet": f"magnet:?xt=urn:btih:{hash}"},
             )
             magnet = await magnet.json()
@@ -165,7 +169,7 @@ class StremThru:
                 return
 
             link = await self.session.post(
-                f"{self.base_url}/link/generate",
+                f"{self.base_url}/link/generate?client_ip={self.client_ip}",
                 json={"link": file["link"]},
             )
             link = await link.json()

--- a/comet/debrid/stremthru.py
+++ b/comet/debrid/stremthru.py
@@ -149,11 +149,14 @@ class StremThru:
             )
             magnet = await magnet.json()
 
+            if magnet["data"]["status"] != "downloaded":
+                return
+
             file = next(
                 (
                     file
                     for file in magnet["data"]["files"]
-                    if file["index"] == int(index)
+                    if str(file["index"]) == index or file["name"] == index
                 ),
                 None,
             )

--- a/comet/debrid/stremthru.py
+++ b/comet/debrid/stremthru.py
@@ -20,10 +20,11 @@ class StremThru:
         if not self.is_supported_store(debrid_service):
             raise ValueError(f"unsupported store: {debrid_service}")
 
-        if debrid_service == "stremthru":
+        store, token = self.parse_store_creds(debrid_service, token)
+        if store == "stremthru":
             session.headers["Proxy-Authorization"] = f"Basic {token}"
         else:
-            session.headers["X-StremThru-Store-Name"] = debrid_service
+            session.headers["X-StremThru-Store-Name"] = store
             session.headers["X-StremThru-Store-Authorization"] = f"Bearer {token}"
 
         session.headers["User-Agent"] = "comet"
@@ -34,11 +35,21 @@ class StremThru:
         self.client_ip = ip
 
     @staticmethod
+    def parse_store_creds(debrid_service, token: str = ""):
+        if debrid_service != "stremthru":
+            return debrid_service, token
+        if ":" in token:
+            parts = token.split(":")
+            return parts[0], parts[1]
+        return debrid_service, token
+
+    @staticmethod
     def is_supported_store(name: Optional[str]):
         return (
             name == "stremthru"
             or name == "alldebrid"
             or name == "debridlink"
+            or name == "easydebrid"
             or name == "premiumize"
             or name == "realdebrid"
             or name == "torbox"

--- a/comet/debrid/stremthru.py
+++ b/comet/debrid/stremthru.py
@@ -58,11 +58,12 @@ class StremThru:
 
         return False
 
-    async def get_instant(self, magnets: list):
+    async def get_instant(self, magnets: list, sid: Optional[str] = None):
         try:
-            magnet = await self.session.get(
-                f"{self.base_url}/magnets/check?magnet={','.join(magnets)}&client_ip={self.client_ip}"
-            )
+            url = f"{self.base_url}/magnets/check?magnet={','.join(magnets)}&client_ip={self.client_ip}"
+            if sid:
+                url = f"{url}&sid={sid}"
+            magnet = await self.session.get(url)
             return await magnet.json()
         except Exception as e:
             logger.warning(
@@ -70,7 +71,14 @@ class StremThru:
             )
 
     async def get_files(
-        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool
+        self,
+        torrent_hashes: list,
+        type: str,
+        season: str,
+        episode: str,
+        kitsu: bool,
+        video_id: Optional[str] = None,
+        **kwargs,
     ):
         chunk_size = 25
         chunks = [
@@ -80,7 +88,7 @@ class StremThru:
 
         tasks = []
         for chunk in chunks:
-            tasks.append(self.get_instant(chunk))
+            tasks.append(self.get_instant(chunk, sid=video_id))
 
         responses = await asyncio.gather(*tasks)
 

--- a/comet/debrid/torbox.py
+++ b/comet/debrid/torbox.py
@@ -41,7 +41,7 @@ class TorBox:
             )
 
     async def get_files(
-        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool
+        self, torrent_hashes: list, type: str, season: str, episode: str, kitsu: bool, **kwargs
     ):
         chunk_size = 50
         chunks = [

--- a/comet/main.py
+++ b/comet/main.py
@@ -156,6 +156,8 @@ def start_log():
         "COMET",
         f"Debrid Stream Proxy: {bool(settings.PROXY_DEBRID_STREAM)} - Password: {settings.PROXY_DEBRID_STREAM_PASSWORD} - Max Connections: {settings.PROXY_DEBRID_STREAM_MAX_CONNECTIONS} - Default Debrid Service: {settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE} - Default Debrid API Key: {settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY}",
     )
+    if settings.STREMTHRU_DEFAULT_URL:
+        logger.log("COMET", f"Default StremThru URL: {settings.STREMTHRU_DEFAULT_URL}")
     logger.log("COMET", f"Title Match Check: {bool(settings.TITLE_MATCH_CHECK)}")
     logger.log("COMET", f"Remove Adult Content: {bool(settings.REMOVE_ADULT_CONTENT)}")
     logger.log("COMET", f"Custom Header HTML: {bool(settings.CUSTOM_HEADER_HTML)}")

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -546,6 +546,7 @@
                     <sl-option value="alldebrid">All-Debrid</sl-option>
                     <sl-option value="premiumize">Premiumize</sl-option>
                     <sl-option value="realdebrid">Real-Debrid</sl-option>
+                    <sl-option value="stremthru">StremThru</sl-option>
                 </sl-select>
             </div>
 
@@ -555,6 +556,10 @@
                     <a id="apiKeyLink" href="https://torbox.app/settings" target="_blank">Get It Here</a>
                 </label>
                 <sl-input id="debridApiKey" placeholder="Enter API key" help-text="If no key is specified, you'll get direct torrents!"></sl-input>
+            </div>
+
+            <div class="form-item">
+                <sl-input id="stremthruUrl" label="StremThru URL" placeholder="{{stremthruDefaultUrl}}" help-text="URL for StremThru."></sl-input>
             </div>
 
             <sl-details summary="Advanced Settings">
@@ -581,6 +586,8 @@
                         apiKeyLink.href = "https://torbox.app/settings";
                     } else if (selectedService === "debridlink") {
                         apiKeyLink.href = "https://debrid-link.com/webapp/apikey";
+                    } else if (selectedService === "stremthru") {
+                        apiKeyLink.href = "https://github.com/MunifTanjim/stremthru?tab=readme-ov-file#configuration";
                     }
                 });
             </script>
@@ -725,6 +732,7 @@
                         const resultFormat = Array.from(document.getElementById("resultFormat").selectedOptions).map(option => option.value);
                         const debridService = document.getElementById("debridService").value;
                         const debridApiKey = document.getElementById("debridApiKey").value;
+                        const stremthruUrl = document.getElementById("stremthruUrl").value;
                         const debridStreamProxyPassword = document.getElementById("debridStreamProxyPassword").value;
                         const selectedLanguages = languages.length === defaultLanguages.length && languages.every((val, index) => val === defaultLanguages[index]) ? ["All"] : languages;
                         const selectedResolutions = resolutions.length === defaultResolutions.length && resolutions.every((val, index) => val === defaultResolutions[index]) ? ["All"] : resolutions;
@@ -742,6 +750,7 @@
                             languages: selectedLanguages,
                             debridService: debridService,
                             debridApiKey: debridApiKey,
+                            stremthruUrl: stremthruUrl,
                             debridStreamProxyPassword: debridStreamProxyPassword,
                         };
                     }
@@ -807,6 +816,8 @@
                             document.getElementById("indexers").value = settings.indexers;
                         if (settings.languages !== null && settings.languages != "All")
                             document.getElementById("languages").value = settings.languages;
+                        if (settings.stremthruUrl !== null)
+                          document.getElementById("stremthruUrl").value = settings.stremthruUrl;
                         if (settings.resolutions !== null && settings.resolutions != "All")
                             document.getElementById("resolutions").value = settings.resolutions;
                         if (settings.resultFormat !== null && settings.resultFormat != "All")

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -575,6 +575,7 @@
                 document.getElementById("debridService").addEventListener("sl-change", function(event) {
                     const selectedService = event.target.value;
                     const apiKeyLink = document.getElementById("apiKeyLink");
+                    const apiKeyInput = document.getElementById("debridApiKey");
 
                     if (selectedService === "realdebrid") {
                         apiKeyLink.href = "https://real-debrid.com/apitoken";
@@ -588,6 +589,11 @@
                         apiKeyLink.href = "https://debrid-link.com/webapp/apikey";
                     } else if (selectedService === "stremthru") {
                         apiKeyLink.href = "https://github.com/MunifTanjim/stremthru?tab=readme-ov-file#configuration";
+                    }
+                    if (selectedService === "stremthru") {
+                      apiKeyInput.helpText = "Enter Credential ('store_name:store_token' or base64 encoded basic token from 'STREMTHRU_PROXY_AUTH' config)"
+                    } else {
+                      apiKeyInput.helpText = "If no key is specified, you'll get direct torrents!"
                     }
                 });
             </script>

--- a/comet/utils/config.py
+++ b/comet/utils/config.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from comet.debrid.stremthru import StremThru
+from comet.utils.models import settings
+
+
+def is_proxy_stream_enabled(config: dict[str, Any]):
+    return (
+        bool(settings.PROXY_DEBRID_STREAM) and config["debridStreamProxyPassword"] != ""
+    )
+
+
+def is_proxy_stream_authed(config: dict[str, Any]):
+    return settings.PROXY_DEBRID_STREAM_PASSWORD == config["debridStreamProxyPassword"]
+
+
+def should_use_stremthru(config: dict[str, Any]):
+    return config["stremthruUrl"] and StremThru.is_supported_store(
+        config["debridService"]
+    )
+
+
+def should_skip_proxy_stream(config: dict[str, Any]):
+    return config["stremthruUrl"] and config["debridService"] == "stremthru"
+
+
+def should_use_fallback_debrid_config(config: dict[str, Any]):
+    if is_proxy_stream_authed(config) and config["debridApiKey"] == "":
+        return True
+
+    return False
+
+
+def prepare_debrid_config(config: dict[str, Any]):
+    if should_use_fallback_debrid_config(config):
+        config["debridService"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE
+        config["debridApiKey"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY
+
+    if not config["stremthruUrl"]:
+        config["stremthruUrl"] = settings.STREMTHRU_DEFAULT_URL

--- a/comet/utils/config.py
+++ b/comet/utils/config.py
@@ -21,7 +21,11 @@ def should_use_stremthru(config: dict[str, Any]):
 
 
 def should_skip_proxy_stream(config: dict[str, Any]):
-    return config["stremthruUrl"] and config["debridService"] == "stremthru"
+    return (
+        config["stremthruUrl"]
+        and config["debridService"] == "stremthru"
+        and ":" not in config["debridApiKey"]
+    )
 
 
 def should_use_fallback_debrid_config(config: dict[str, Any]):
@@ -36,8 +40,8 @@ def prepare_debrid_config(config: dict[str, Any]):
         config["debridService"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE
         config["debridApiKey"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY
 
-    if (
-        not config["stremthruUrl"]
-        and config["debridService"] in settings.STREMTHRU_AUTO_ENABLED_DEBRID_SERVICES
+    if not config["stremthruUrl"] and (
+        config["debridService"] == "stremthru"
+        or config["debridService"] in settings.STREMTHRU_AUTO_ENABLED_DEBRID_SERVICES
     ):
         config["stremthruUrl"] = settings.STREMTHRU_DEFAULT_URL

--- a/comet/utils/config.py
+++ b/comet/utils/config.py
@@ -36,5 +36,8 @@ def prepare_debrid_config(config: dict[str, Any]):
         config["debridService"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE
         config["debridApiKey"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY
 
-    if not config["stremthruUrl"]:
+    if (
+        not config["stremthruUrl"]
+        and config["debridService"] in settings.STREMTHRU_AUTO_ENABLED_DEBRID_SERVICES
+    ):
         config["stremthruUrl"] = settings.STREMTHRU_DEFAULT_URL

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -269,6 +269,7 @@ def get_debrid_extension(debridService: str, debridApiKey: str = None):
         "premiumize": "PM",
         "torbox": "TB",
         "debridlink": "DL",
+        "stremthru": "ST",
     }
 
     return debrid_extensions.get(debridService, None)

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -269,10 +269,15 @@ def get_debrid_extension(debridService: str, debridApiKey: str = None):
         "premiumize": "PM",
         "torbox": "TB",
         "debridlink": "DL",
+        "easydebrid": "ED",
         "stremthru": "ST",
     }
 
-    return debrid_extensions.get(debridService, None)
+    extension = debrid_extensions.get(debridService, None)
+    if extension == "ST" and debridApiKey and ":" in debridApiKey:
+        ext = debrid_extensions[debridApiKey.split(":")[0]]
+        return f"{extension}({ext})" if extension != ext else extension
+    return extension
 
 
 async def get_indexer_manager(

--- a/comet/utils/models.py
+++ b/comet/utils/models.py
@@ -42,6 +42,7 @@ class AppSettings(BaseSettings):
     PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY: Optional[str] = None
     TITLE_MATCH_CHECK: Optional[bool] = True
     REMOVE_ADULT_CONTENT: Optional[bool] = False
+    STREMTHRU_DEFAULT_URL: Optional[str] = None
 
     @field_validator("DASHBOARD_ADMIN_PASSWORD")
     def set_dashboard_admin_password(cls, v, values):
@@ -78,6 +79,7 @@ class ConfigModel(BaseModel):
     debridService: str
     debridApiKey: str
     debridStreamProxyPassword: Optional[str] = ""
+    stremthruUrl: Optional[str] = None
 
     @field_validator("indexers")
     def check_indexers(cls, v, values):
@@ -123,7 +125,7 @@ class ConfigModel(BaseModel):
 
     @field_validator("debridService")
     def check_debrid_service(cls, v):
-        if v not in ["realdebrid", "alldebrid", "premiumize", "torbox", "debridlink"]:
+        if v not in ["realdebrid", "alldebrid", "premiumize", "torbox", "debridlink", "stremthru"]:
             raise ValueError("Invalid debridService")
         return v
 

--- a/comet/utils/models.py
+++ b/comet/utils/models.py
@@ -42,7 +42,12 @@ class AppSettings(BaseSettings):
     PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY: Optional[str] = None
     TITLE_MATCH_CHECK: Optional[bool] = True
     REMOVE_ADULT_CONTENT: Optional[bool] = False
-    STREMTHRU_DEFAULT_URL: Optional[str] = None
+    STREMTHRU_DEFAULT_URL: Optional[str] = "https://stremthru.elfhosted.com"
+    STREMTHRU_AUTO_ENABLED_DEBRID_SERVICES: List[str] = [
+        "realdebrid",
+        "alldebrid",
+        "debridlink",
+    ]
 
     @field_validator("DASHBOARD_ADMIN_PASSWORD")
     def set_dashboard_admin_password(cls, v, values):


### PR DESCRIPTION
**Why?**

- With StremThru, user can change debrid providers without re-configuring the Stremio addon.
- Just another debrid provider, that you basically self-host. Give people options.
- If addons use StremThru, user can configure vpn/proxy for StremThru only, instead of configuring it for each addons individually.

---

![image](https://github.com/user-attachments/assets/2afc641c-e039-4bd8-8448-008e096329c6)

![image](https://github.com/user-attachments/assets/c4be59f3-002b-46b7-b76c-0403fe14bf68)

To enable StremThru, you need to:

- Add `STREMTHRU_DEFAULT_URL` environment variable
- Or add "StremThru URL" config in `/configure` page

**StremThru enabled with another Debrid Service**

If that debrid service is supported by StremThru, Comet will call StremThru to interact with that debrid service.

**StremThru enabled and set as Debrid Service**

Comet will not know which "actual" debrid service user is using, it'll just call StremThru as if it's the debrid service itself.