### PR TITLE
Improve title filtering and tv shows results

### DIFF
--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -108,7 +108,7 @@ async def stream(request: Request, b64config: str, type: str, id: str):
         name = translate(name)
         log_name = name
         if type == "series":
-            log_name = f"{name} S0{season}E0{episode}"
+            log_name = f"{name} S{season:02d}E{episode:02d}"
 
         if (
             settings.PROXY_DEBRID_STREAM
@@ -266,8 +266,8 @@ async def stream(request: Request, b64config: str, type: str, id: str):
             if type == "series":
                 search_terms = []
                 if not kitsu:
-                    search_terms.append(f"{name} S0{season}E0{episode}")
-                    search_terms.append(f"{name} s0{season}e0{episode}")
+                    search_terms.append(f"{name} S{season:02d}E{episode:02d}")
+                    search_terms.append(f"{name} s{season:02d}e{episode:02d}")
                 else:
                     search_terms.append(f"{name} {episode}")
             tasks.extend(

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -264,8 +264,10 @@ async def stream(request: Request, b64config: str, type: str, id: str):
 
             search_terms = [name]
             if type == "series":
+                search_terms = []
                 if not kitsu:
                     search_terms.append(f"{name} S0{season}E0{episode}")
+                    search_terms.append(f"{name} s0{season}e0{episode}")
                 else:
                     search_terms.append(f"{name} {episode}")
             tasks.extend(

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -502,7 +502,7 @@ async def filter(torrents: list, name: str, year: int):
 
         parsed = parse(title)
 
-        if parsed.parsed_title and not (match_titles(name, parsed.parsed_title)):
+        if parsed.parsed_title and not match_titles(name, parsed.parsed_title):
             results.append((index, False))
             continue
 

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -477,7 +477,12 @@ async def filter(torrents: list, name: str, year: int):
 
         parsed = parse(title)
 
-        if parsed.parsed_title and not title_match(name, parsed.parsed_title):
+        def title_sub_match(correct_title: str, torrent_title: str):
+            correct_title = correct_title.lower()
+            torrent_title = torrent_title.lower()
+            return correct_title in torrent_title or torrent_title in correct_title
+
+        if parsed.parsed_title and not (title_match(name, parsed.parsed_title) or title_sub_match(name, parsed.parsed_title)):
             results.append((index, False))
             continue
 

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -467,10 +467,10 @@ async def get_mediafusion(log_name: str, type: str, full_id: str):
 
 
 async def filter(torrents: list, name: str, year: int):
-    def title_sub_match(correct_title: str, torrent_title: str):
-        correct_title = correct_title.lower()
+    def title_sub_match(imdb_title: str, torrent_title: str):
+        imdb_title = imdb_title.lower()
         torrent_title = torrent_title.lower()
-        return correct_title in torrent_title or torrent_title in correct_title
+        return imdb_title in torrent_title or torrent_title in imdb_title
 
     results = []
     for torrent in torrents:

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -467,6 +467,11 @@ async def get_mediafusion(log_name: str, type: str, full_id: str):
 
 
 async def filter(torrents: list, name: str, year: int):
+    def title_sub_match(correct_title: str, torrent_title: str):
+        correct_title = correct_title.lower()
+        torrent_title = torrent_title.lower()
+        return correct_title in torrent_title or torrent_title in correct_title
+
     results = []
     for torrent in torrents:
         index = torrent[0]
@@ -476,11 +481,6 @@ async def filter(torrents: list, name: str, year: int):
             title = title.split("\n")[1]
 
         parsed = parse(title)
-
-        def title_sub_match(correct_title: str, torrent_title: str):
-            correct_title = correct_title.lower()
-            torrent_title = torrent_title.lower()
-            return correct_title in torrent_title or torrent_title in correct_title
 
         if parsed.parsed_title and not (title_match(name, parsed.parsed_title) or title_sub_match(name, parsed.parsed_title)):
             results.append((index, False))

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -480,10 +480,15 @@ def match_titles(imdb_title: str, torrent_title: str, threshold: int = 80) -> bo
     bool: True if the titles match, False otherwise.
     """
     # Calculate the fuzzy match ratio
-    match_ratio = fuzz.ratio(imdb_title, torrent_title)
+    # The idea is that ratio will give very low score to garbage ratio but will also give mid/average 
+    # score to some good results. The WRatio will make sure these mid score passes the filter.
+    base_ratio = fuzz.ratio(imdb_title, torrent_title) # strict ratio
+    w_ratio = fuzz.WRatio(imdb_title, torrent_title) # less strict ratio
+    # The weight of the ratios needs to be adjusted because basic ratio is too strict.
+    match_ratio = (base_ratio*0.7 + w_ratio*1.3)/2
 
-    # Check if the fuzzy match ratio meets the thresholds
-    return match_ratio >= threshold
+    # Check if the fuzzy match ratio meets the thresholds 
+    return match_ratio >= threshold 
 
 
 async def filter(torrents: list, name: str, year: int):

--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -7,7 +7,7 @@ import PTT
 import asyncio
 import orjson
 
-from RTN import parse, title_match
+from RTN import parse
 from curl_cffi import requests
 from fastapi import Request
 from fuzzywuzzy import fuzz
@@ -466,30 +466,25 @@ async def get_mediafusion(log_name: str, type: str, full_id: str):
 
     return results
 
-def match_titles(imdb_title, torrent_title, threshold=80, token_overlap_threshold=0.5):
+
+def match_titles(imdb_title: str, torrent_title: str, threshold: int = 80) -> bool:
     """
-    Match movie/TV show titles using a combination of fuzzy string matching and token overlap.
+    Match movie/TV show titles using fuzzy string matching.
 
     Parameters:
     imdb_title (str): The title from the IMDB data source.
     torrent_title (str): The title from the torrent data source.
     threshold (int): The minimum fuzzy match ratio to consider the titles a match.
-    token_overlap_threshold (float): The minimum proportion of overlapping tokens to consider the titles a match.
 
     Returns:
     bool: True if the titles match, False otherwise.
     """
     # Calculate the fuzzy match ratio
-    match_ratio = fuzz.token_set_ratio(imdb_title, torrent_title)
+    match_ratio = fuzz.ratio(imdb_title, torrent_title)
 
-    # Calculate the proportion of overlapping tokens
-    imdb_tokens = set(imdb_title.lower().split())
-    torrent_tokens = set(torrent_title.lower().split())
-    common_tokens = imdb_tokens.intersection(torrent_tokens)
-    token_overlap_ratio = len(common_tokens) / max(len(imdb_tokens), len(torrent_tokens))
+    # Check if the fuzzy match ratio meets the thresholds
+    return match_ratio >= threshold
 
-    # Check if both the fuzzy match ratio and token overlap ratio meet the thresholds
-    return match_ratio >= threshold and token_overlap_ratio >= token_overlap_threshold
 
 async def filter(torrents: list, name: str, year: int):
     results = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ jinja2 = "*"
 rank-torrent-name = "*"
 parsett = "*"
 fuzzywuzzy = "*"
+python-Levenshtein = "*"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ aiosqlite = "*"
 jinja2 = "*"
 rank-torrent-name = "*"
 parsett = "*"
+fuzzywuzzy = "*"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
After some experimentation, I managed to improve the results for tv shows and title matching :

- The first issue was that the title matching is using Levenshtein ratio, which does not always work when comparing torrent title and the title from imdb. For example, on imdb the title "Daredevil" corresponds to "Marvel Daredevil" in torrents. However the similarity ratio is too low because of the additional word. Fuzzy Wuzzy algorithm is a more advanced version of the Levenshtein distance which doesn't return low score for the cases I encountered (including the one I mentioned above).
-  The second improvement is to not search for the name of the tv show in the index manager because it takes much more time to retrieve given the number of results and is not necessary.  I managed to get more relevant results with the changes. There were also no results for episodes/seasons greater than 10.