### PR TITLE
fix: check RD API HTTP status code

### DIFF
--- a/comet/debrid/realdebrid.py
+++ b/comet/debrid/realdebrid.py
@@ -65,7 +65,10 @@ class RealDebrid:
 
         if type == "series":
             for hash, details in availability.items():
-                if "rd" not in details:
+                if not isinstance(details, dict):
+                    continue
+
+                elif "rd" not in details:
                     continue
 
                 for variants in details["rd"]:
@@ -98,7 +101,10 @@ class RealDebrid:
                         break
         else:
             for hash, details in availability.items():
-                if "rd" not in details:
+                if not isinstance(details, dict):
+                    continue
+
+                elif "rd" not in details:
                     continue
 
                 for variants in details["rd"]:

--- a/comet/debrid/realdebrid.py
+++ b/comet/debrid/realdebrid.py
@@ -60,7 +60,6 @@ class RealDebrid:
         for chunk in chunks:
             tasks.append(self.get_instant(chunk))
 
-        print(f"num tasks: {len(tasks)}")
 
         responses = await asyncio.gather(*tasks)
 

--- a/comet/debrid/realdebrid.py
+++ b/comet/debrid/realdebrid.py
@@ -60,7 +60,6 @@ class RealDebrid:
         for chunk in chunks:
             tasks.append(self.get_instant(chunk))
 
-
         responses = await asyncio.gather(*tasks)
 
         availability = {}

--- a/comet/debrid/realdebrid.py
+++ b/comet/debrid/realdebrid.py
@@ -40,7 +40,7 @@ class RealDebrid:
                 logger.warning(
                     f"Request failed with status {response.status}: {response_json}"
                 )
-                return
+                return {}
             return response_json
         except Exception as e:
             logger.warning(


### PR DESCRIPTION
I was seeing errors where series details returned by the RD api was an empty `list` instead of a `dict`. Without this fix I get the error:
```
 File "/app/comet/debrid/realdebrid.py", line 71, in get_files
    if "rd" not in details:
       ^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'int' is not iterable
```

On further debugging the RD API returns
```
{'error': 'too_many_requests', 'error_code': 34}
```
with HTTP status 429

It looks like RD is rate-limited to [250 requests / min](https://api.real-debrid.com/)

Ideally the number of requests made by comet could be limited to not exceed this limit. Also it seems like checking for HTTP error codes should be done when using other debrid services but I am only able to test with RD