### PR TITLE
fix: correctly handle unsuccessful api calls

### DIFF
--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -66,7 +66,7 @@ async def stream(request: Request, b64config: str, type: str, id: str):
         }
 
     connector = aiohttp.TCPConnector(limit=0)
-    async with aiohttp.ClientSession(connector=connector) as session:
+    async with aiohttp.ClientSession(connector=connector, raise_for_status=True) as session:
         full_id = id
         season = None
         episode = None
@@ -552,7 +552,7 @@ async def playback(request: Request, b64config: str, hash: str, index: str):
         config["debridService"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE
         config["debridApiKey"] = settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(raise_for_status=True) as session:
         # Check for cached download link
         cached_link = await database.fetch_one(
             f"SELECT link, timestamp FROM download_links WHERE debrid_key = '{config['debridApiKey']}' AND hash = '{hash}' AND file_index = '{index}'"


### PR DESCRIPTION
When comet makes api calls to an upstream service (debrid, indexer, etc) and the upstream returns an error response (server error, rate limiting, etc) comet incorrectly parses the response body as a successful response. This causes unhandled exceptions due to logic errors and leads to no streams returned by comet from any sources.

For example if we check too many hashes real-debrid throws a rate-limiting error response for some of the queries on `/torrents/instantAvailability/` endpoint. As a result comet returns no streams at all.

This fix makes failed API requests cause an exception at the right time. The existing code to handle exceptions when making requests then correctly handles these failed responses as well.