### PR TITLE
Catch 503 response exception

### DIFF
--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -634,7 +634,7 @@ async def playback(request: Request, b64config: str, hash: str, index: str):
                 def __init__(self, id: str):
                     self.id = id
 
-                    self.client = httpx.AsyncClient(proxy=proxy)
+                    self.client = httpx.AsyncClient(proxy=proxy, timeout=None)
                     self.response = None
 
                 async def stream_content(self, headers: dict):


### PR DESCRIPTION
AllDebrid streaming issues:
It seems that the download_link HEAD request to Alldebrid returns a 503 but the aiohttp client raises an exception which is not caught and therefore execution is stopped.

Fix:
Catch the 503 response exception and continue to set the proxy on the retry attempt.
Also disables the timeout on the httpx client for the stream request. Unsure if this is needed.