### PR TITLE
Explain that ElfHosted instances include Jackett and Proxystreaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 </p>
 
 # Features
-- The only Stremio addon that can Proxy Debrid Streams to allow use of the Debrid Service on multiple IPs at the same time on the same account!
+- The first Stremio addon to Proxy Debrid Streams to allow use of the Debrid Service on multiple IPs at the same time on the same account!
 - IP-Based Max Connection Limit and Dashboard for Debrid Stream Proxier
 - Jackett and Prowlarr support (change the `INDEXER_MANAGER_TYPE` environment variable to `jackett` or `prowlarr`)
 - [Zilean](https://github.com/iPromKnight/zilean) ([DMM](https://hashlists.debridmediamanager.com/) Scraper) support for even more results
 - [Torrentio](https://torrentio.strem.fun/) Scraper
+- [MediaFusion](https://mediafusion.elfhosted.com/) Scraper
 - Caching system ft. SQLite / PostgreSQL
 - Smart Torrent Ranking powered by [RTN](https://github.com/dreulavelle/rank-torrent-name)
 - Proxy support to bypass debrid restrictions
@@ -25,11 +26,12 @@
 To customize your Comet experience to suit your needs, please first take a look at all the [environment variables](https://github.com/g0ldyy/comet/blob/main/.env-sample)!
 
 ## ElfHosted
-A free, public Comet instance is available at https://comet.elfhosted.com
 
-[ElfHosted](https://elfhosted.com) is a geeky [open-source](https://elfhosted.com/open/) PaaS which provides all the "plumbing" (*hosting, security, updates, etc*) for your self-hosted apps. 
+A free, public Comet instance is available at https://comet.elfhosted.com, but if you need custom indexers, higher-rate-limits, or proxystreaming in a "turn-key" fashion, consider ElfHosted...
 
-ElfHosted offer "one-click" [private Comet instances](https://elfhosted.com/app/comet/), allowing you to customize your indexers, and enabling "Proxy Stream" mode, to permit streaming from multiple source IPs with the same RD token!
+[ElfHosted](https://elfhosted.com) is a geeky [open-source](https://elfhosted.com/open/) PaaS which provides all the "plumbing" (*hosting, security, updates, etc*) for your self-hosted apps.
+
+ElfHosted offer "one-click" [private Comet instances](https://elfhosted.com/app/comet/) bundled with Jackett and 64Mbps proxystreaming, allowing you to customize your indexers and streaming from multiple source IPs with the same RD token, without risking an account ban! (bandwidth boosters are available)
 
 > [!IMPORTANT]
 > Comet is a top-tier app in the [ElfHosted app catalogue](https://elfhosted.com/apps/). 30% of your subscription goes to the app developer :heart:


### PR DESCRIPTION
Signed-off-by: David Young <davidy@funkypenguin.co.nz>