### PR TITLE
fix: pin rank-torrent-name to last working version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,6 @@ dependencies = [
     "mediaflow-proxy",
     "orjson",
     "pydantic-settings",
-    "rank-torrent-name",
+    "rank-torrent-name==1.7.2",
     "uvicorn",
 ]


### PR DESCRIPTION
Due to incompatibilities between the current codebase and the latest version of `rank-torrent-name`, this PR pins the package to the last working version to ensure stability.