### PR TITLE
fix: parse media_id for kitsu movies correctly

### DIFF
--- a/comet/utils/general.py
+++ b/comet/utils/general.py
@@ -291,5 +291,5 @@ def parse_media_id(media_type: str, media_id: str):
         return info[0], int(info[1]), int(info[2])
     elif media_type == "movie" and "kitsu" in media_id:
         info = media_id.split(":")
-        return info[0], int(info[1]), None
+        return int(info[1]), 1, None
     return media_id, None, None

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     container_name: comet
     image: g0ldyy/comet
     restart: unless-stopped
+    network_mode: host
     ports:
       - "8000:8000"
     env_file:


### PR DESCRIPTION
This is one of those "I wonder how it ever worked" kind of things :D

I noticed that kitsu movies were not returning anything ever and then I saw that comet tries to call the kitsu API with `"kitsu"` for the ID as in e.g. https://kitsu.io/api/edge/anime/kitsu which leads to

```json
{
  "errors": [
    {
      "title": "Invalid field value",
      "detail": "kitsu is not a valid value for id.",
      "code": "103",
      "status": "400"
    }
  ]
}
```

Instead we want something like e.g. https://kitsu.io/api/edge/anime/2170

Logging in `parse_media_id` revealed that data always looks like this for kitsu movies

```
general.parse_media_id - media_type: movie, media_id: kitsu:2170
```

I adapted the logic to return the ID instead of the "kitsu" string and checked with a couple of movies. looking good now.