### PR TITLE
[enhance] saner background scraper defaults

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -50,10 +50,10 @@ SCRAPE_WAIT_TIMEOUT=30  # 30 seconds - Max time to wait for other instance to co
 # PostgreSQL recommended for high worker count!           #
 # ======================================================= #
 BACKGROUND_SCRAPER_ENABLED=False
-BACKGROUND_SCRAPER_CONCURRENT_WORKERS=10 # Number of concurrent workers for scraping (adjust depending on whether you are often ratelimited by scrapers)
-BACKGROUND_SCRAPER_INTERVAL=3600 # Interval between scraping cycles in seconds (min: 300)
-BACKGROUND_SCRAPER_MAX_MOVIES_PER_RUN=1000 # Maximum number of movies to scrape per run
-BACKGROUND_SCRAPER_MAX_SERIES_PER_RUN=500 # Maximum number of series to scrape per run
+BACKGROUND_SCRAPER_CONCURRENT_WORKERS=2 # Number of concurrent workers for scraping (adjust depending on whether you are often ratelimited by scrapers)
+BACKGROUND_SCRAPER_INTERVAL=300 # Interval between scraping cycles in seconds (min: 300)
+BACKGROUND_SCRAPER_MAX_MOVIES_PER_RUN=20 # Maximum number of movies to scrape per run
+BACKGROUND_SCRAPER_MAX_SERIES_PER_RUN=2 # Maximum number of series to scrape per run
 
 # ============================== #
 # Debrid Proxy Configuration     #


### PR DESCRIPTION
saner defaults, so people don't turn this on and slam all the public instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default background scraping settings to favor smaller, more frequent cycles: lowered concurrent workers, reduced per-run item limits, and shortened the interval between runs. This delivers steadier updates, reduces resource spikes, and improves out-of-the-box stability—especially on modest hardware. Users can still customize these values via environment configuration to suit their deployment needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->