### PR TITLE
reduce torrentio scraper aggressiveness

### DIFF
--- a/comet/scrapers/manager.py
+++ b/comet/scrapers/manager.py
@@ -20,7 +20,7 @@ from comet.utils.debrid import cache_availability, get_cached_availability
 from comet.debrid.manager import retrieve_debrid_availability
 from comet.utils.general import associate_urls_credentials
 from .zilean import get_zilean
-from .torrentio import get_torrentio, get_torrentio_with_delay
+from .torrentio import get_torrentio
 from .mediafusion import get_mediafusion
 from .jackett import get_jackett
 from .prowlarr import get_prowlarr
@@ -398,12 +398,8 @@ def get_all_torrentio_tasks(manager):
         urls = [urls]
 
     tasks = []
-    for i, url in enumerate(urls):
-        # Add staggered delays to reduce simultaneous requests
-        if i > 0:
-            tasks.append(get_torrentio_with_delay(manager, url, i * 1.0))
-        else:
-            tasks.append(get_torrentio(manager, url))
+    for url in urls:
+        tasks.append(get_torrentio(manager, url))
     return tasks
 
 


### PR DESCRIPTION
Adds delays and timeouts so the torrentio scraper isn't as aggressive(the beast, was not a fan- and decided to block warp ip's as a result)

This is just a simple PR with a base delay, configure it how you'd like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable request timeout (default 10s) for network requests, improving responsiveness and preventing long hangs.

- Bug Fixes
  - Implemented per-URL rate limiting for Torrentio requests to reduce server throttling and timeouts.
  - Added brief backoff after failed Torrentio requests to avoid rapid retry loops and stabilize results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->