### PR TITLE
feat: enhance Nyaa scraper with anime-only option and integrate anime…

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -90,6 +90,7 @@ COMET_URL=https://comet.elfhosted.com
 # COMET_URL='["https://comet1.example.com", "https://comet2.example.com"]'
 
 SCRAPE_NYAA=True
+NYAA_ANIME_ONLY=True # Only scrape Nyaa if the content is anime
 NYAA_MAX_CONCURRENT_PAGES=5 # Maximum number of concurrent requests to Nyaa (consider reducing if you are often ratelimited by Nyaa)
 
 SCRAPE_ZILEAN=True

--- a/comet/main.py
+++ b/comet/main.py
@@ -7,6 +7,7 @@ import traceback
 import uvicorn
 import os
 import asyncio
+import aiohttp
 
 from contextlib import asynccontextmanager
 
@@ -30,6 +31,7 @@ from comet.utils.logger import logger
 from comet.utils.models import settings
 from comet.utils.bandwidth_monitor import bandwidth_monitor
 from comet.background_scraper.worker import background_scraper
+from comet.utils.anime_mapper import anime_mapper
 
 
 class LoguruMiddleware(BaseHTTPMiddleware):
@@ -53,6 +55,10 @@ class LoguruMiddleware(BaseHTTPMiddleware):
 async def lifespan(app: FastAPI):
     await setup_database()
     await download_best_trackers()
+
+    # Load anime ID mapping for enhanced metadata and anime detection
+    async with aiohttp.ClientSession() as session:
+        await anime_mapper.load_anime_mapping(session)
 
     # Initialize bandwidth monitoring system
     await bandwidth_monitor.initialize()
@@ -197,7 +203,7 @@ def start_log():
 
     logger.log(
         "COMET",
-        f"Nyaa Scraper: {bool(settings.SCRAPE_NYAA)} - Kitsu Only: {bool(settings.NYAA_KITSU_ONLY)}",
+        f"Nyaa Scraper: {bool(settings.SCRAPE_NYAA)} - Anime Only: {bool(settings.NYAA_ANIME_ONLY)}",
     )
 
     zilean_url = f" - {settings.ZILEAN_URL}" if settings.SCRAPE_ZILEAN else ""

--- a/comet/scrapers/nyaa.py
+++ b/comet/scrapers/nyaa.py
@@ -65,7 +65,7 @@ async def scrape_nyaa_page(
         response = await session.get(url)
         if response.status_code != 200:
             logger.warning(
-                f"Failed to scrape Nyaa page {page} (consider reducing NYAA_MAX_CONCURRENT_PAGES): {response.status_code}"
+                f"Failed to scrape Nyaa page {page} (consider reducing NYAA_MAX_CONCURRENT_PAGES): HTTP {response.status_code}"
             )
             return []
 
@@ -82,7 +82,7 @@ async def get_all_nyaa_pages(session: requests.AsyncSession, query: str):
     first_page_url = f"https://nyaa.si/?q={query}"
     response = await session.get(first_page_url)
     if response.status_code != 200:
-        logger.warning(f"Failed to scrape Nyaa page 1: {response.status_code}")
+        logger.warning(f"Failed to scrape Nyaa page 1: HTTP {response.status_code}")
         return []
 
     first_page_text = response.text

--- a/comet/utils/anime_mapper.py
+++ b/comet/utils/anime_mapper.py
@@ -1,0 +1,65 @@
+import aiohttp
+import orjson
+
+from comet.utils.logger import logger
+
+
+class AnimeMapper:
+    def __init__(self):
+        self.kitsu_to_imdb = {}
+        self.imdb_to_kitsu = {}
+        self.anime_imdb_ids = set()
+        self.loaded = False
+
+    async def load_anime_mapping(self, session: aiohttp.ClientSession):
+        try:
+            url = "https://raw.githubusercontent.com/Fribb/anime-lists/refs/heads/master/anime-list-full.json"
+            response = await session.get(url, timeout=30)
+
+            if response.status != 200:
+                logger.error(f"Failed to load anime mapping: HTTP {response.status}")
+                return False
+
+            text = await response.text()
+            data = orjson.loads(text)
+
+            kitsu_count = 0
+            imdb_count = 0
+
+            for entry in data:
+                kitsu_id = entry.get("kitsu_id")
+                imdb_id = entry.get("imdb_id")
+
+                if kitsu_id and imdb_id:
+                    self.kitsu_to_imdb[kitsu_id] = imdb_id
+                    self.imdb_to_kitsu[imdb_id] = kitsu_id
+                    self.anime_imdb_ids.add(imdb_id)
+                    imdb_count += 1
+
+                if kitsu_id:
+                    kitsu_count += 1
+
+            self.loaded = True
+            logger.log(
+                "COMET",
+                f"✅ Anime mapping loaded: {kitsu_count} Kitsu entries, {imdb_count} with IMDB IDs",
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Exception while loading anime mapping: {e}")
+            return False
+
+    def get_imdb_from_kitsu(self, kitsu_id: int):
+        return self.kitsu_to_imdb.get(kitsu_id)
+
+    def get_kitsu_from_imdb(self, imdb_id: str):
+        return self.imdb_to_kitsu.get(imdb_id)
+
+    def is_anime(self, imdb_id: str):
+        return imdb_id in self.anime_imdb_ids
+
+    def is_loaded(self):
+        return self.loaded
+
+
+anime_mapper = AnimeMapper()

--- a/comet/utils/anime_mapper.py
+++ b/comet/utils/anime_mapper.py
@@ -14,7 +14,7 @@ class AnimeMapper:
     async def load_anime_mapping(self, session: aiohttp.ClientSession):
         try:
             url = "https://raw.githubusercontent.com/Fribb/anime-lists/refs/heads/master/anime-list-full.json"
-            response = await session.get(url, timeout=30)
+            response = await session.get(url)
 
             if response.status != 200:
                 logger.error(f"Failed to load anime mapping: HTTP {response.status}")

--- a/comet/utils/models.py
+++ b/comet/utils/models.py
@@ -57,7 +57,7 @@ class AppSettings(BaseSettings):
     SCRAPE_COMET: Optional[bool] = False
     COMET_URL: Union[str, List[str]] = "https://comet.elfhosted.com"
     SCRAPE_NYAA: Optional[bool] = False
-    NYAA_KITSU_ONLY: Optional[bool] = False
+    NYAA_ANIME_ONLY: Optional[bool] = True
     NYAA_MAX_CONCURRENT_PAGES: Optional[int] = 5
     SCRAPE_ZILEAN: Optional[bool] = False
     ZILEAN_URL: Union[str, List[str]] = "https://zilean.elfhosted.com"


### PR DESCRIPTION
… mapping functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Smarter metadata aliases by merging multiple sources for richer titles.
  * Automatic anime detection via an online mapping to guide Nyaa scraping.
* Configuration
  * Added NYAA_ANIME_ONLY (default: enabled) to restrict Nyaa scraping to anime; replaces prior Kitsu-only flag.
* Improvements
  * Startup logs now show Nyaa status and Anime Only setting.
  * Nyaa scrape warnings include clearer HTTP status messages.
* Documentation
  * .env sample updated to include NYAA_ANIME_ONLY.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->