### PR TITLE
Updated documentation for db_cli

### DIFF
--- a/comet/db_cli.py
+++ b/comet/db_cli.py
@@ -178,7 +178,7 @@ Examples:
   python -m comet.db_cli export --tables torrents,metadata_cache --output ./backup/
   
   # Export all tables with compression
-  python -m comet.db_cli export --output ./backup/ --compress
+  python -m comet.db_cli export --output ./backup/
   
   # Import specific tables
   python -m comet.db_cli import --input ./backup/ --tables torrents


### PR DESCRIPTION
Removed --compress argument in documentation as there is no argument and it is done automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help/epilog to simplify the export example, removing the --compress flag and showing a straightforward invocation with --output.
  * Refined example wording for clarity and consistency with current behavior.
  * These updates appear in the inline --help output and usage guidance when invoking the tool.
  * No functional behavior changed; this is a documentation-only improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->