### PR TITLE
Add SELinux option for volume bind mount

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./data/comet:/app/data
+      - ./data/comet:/app/data:z
     healthcheck:
       test: wget -qO- http://127.0.0.1:8000/health
       interval: 30s


### PR DESCRIPTION
On systems with SELinux, bind mounts in user folders don't have the necessary SELinux labels to be accessed by containers. Adding the `z` option allows the mount to be accessed by any container and it shouldn't have any side effects on other systems.

Docs: https://docs.docker.com/reference/compose-file/services/#volumes

<img width="917" height="509" alt="image" src="https://github.com/user-attachments/assets/827b4d80-8213-4b41-861c-9704866636dd" />

# Before:
<img width="661" height="72" alt="image" src="https://github.com/user-attachments/assets/98211dfc-93d0-480f-b035-eba094be9c6c" />

<img width="1165" height="212" alt="image" src="https://github.com/user-attachments/assets/8cf50f46-dc90-4da9-93b7-bd0693a5536d" />



# After:

<img width="728" height="91" alt="image" src="https://github.com/user-attachments/assets/7921226c-c043-4b90-8240-c7eb2103b55a" />

<img width="913" height="58" alt="image" src="https://github.com/user-attachments/assets/68000ae7-a077-45e6-9b6a-1e862c2016d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission conflicts on SELinux-enabled systems by adjusting container volume options, reducing startup failures and read/write errors during local and self-hosted deployments.

* **Chores**
  * Updated Docker Compose volume configuration to be SELinux-compatible for broader platform support.
  * Maintains existing service behavior and health checks with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->