### PR TITLE
Update prowlarr.py to include timeout from the settings

### DIFF
--- a/comet/scrapers/prowlarr.py
+++ b/comet/scrapers/prowlarr.py
@@ -82,9 +82,12 @@ async def get_prowlarr(manager, session: aiohttp.ClientSession, title: str, seen
     try:
         indexers = [indexer.lower() for indexer in settings.INDEXER_MANAGER_INDEXERS]
 
+        timeout = aiohttp.ClientTimeout(total=settings.INDEXER_MANAGER_TIMEOUT)
+
         get_indexers = await session.get(
             f"{settings.INDEXER_MANAGER_URL}/api/v1/indexer",
             headers={"X-Api-Key": settings.INDEXER_MANAGER_API_KEY},
+            timeout=timeout,  # <-- ADDED TIMEOUT
         )
         get_indexers = await get_indexers.json()
 
@@ -99,6 +102,7 @@ async def get_prowlarr(manager, session: aiohttp.ClientSession, title: str, seen
         response = await session.get(
             f"{settings.INDEXER_MANAGER_URL}/api/v1/search?query={title}&indexerIds={'&indexerIds='.join(str(indexer_id) for indexer_id in indexers_id)}&type=search",
             headers={"X-Api-Key": settings.INDEXER_MANAGER_API_KEY},
+            timeout=timeout,  # <-- ADDED TIMEOUT
         )
         response = await response.json()
 


### PR DESCRIPTION
Update prowlarr.py to include timeout from the settings, as it is only being applied to Jackett scraper currently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved stability and responsiveness by enforcing network timeouts for indexer listing and search operations. This prevents occasional hangs when indexers are slow or unresponsive, leading to quicker failure handling and smoother recovery. Users should experience fewer lockups during indexing and searches, especially under poor network conditions. No changes to search results or normal behavior when services respond promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->