### PR TITLE
feat: add IGNORE_CACHES_FOR_LIVE_SCRAPING option

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -100,6 +100,9 @@ DOWNLOAD_TORRENT_FILES=False # Enable torrent file retrieval (instead of magnet 
 # SCRAPE_NYAA=false          # Completely disabled
 # INDEXER_MANAGER_MODE=live  # Jackett/Prowlarr for live scraping only
 
+# If true, ignores cached torrent and metadata already present in the DB, and scrapes from configured scrapers during LIVE scraping. Use this when you want to force-fetch torrents.
+IGNORE_CACHES_FOR_LIVE_SCRAPING=False
+
 SCRAPE_COMET=False
 COMET_URL=https://comet.elfhosted.com
 # Multi-instance example:

--- a/comet/api/stream.py
+++ b/comet/api/stream.py
@@ -157,7 +157,7 @@ async def stream(
         )
 
         # If both metadata and torrents are cached, skip lock entirely
-        if cached_metadata is not None and cached_torrents_count > 0:
+        if not settings.IGNORE_CACHES_FOR_LIVE_SCRAPING and cached_metadata is not None and cached_torrents_count > 0:
             logger.log("SCRAPER", f"🚀 Fast path: using cached data for {media_id}")
             metadata, aliases = cached_metadata[0], cached_metadata[1]
             # Variables for fast path
@@ -166,7 +166,10 @@ async def stream(
             scrape_lock = None
             needs_scraping = False
         else:
-            # Something is missing, acquire lock for scraping
+            if settings.IGNORE_CACHES_FOR_LIVE_SCRAPING:
+                logger.log("SCRAPER", f"🔄 Ignoring caches for live scraping: {media_id}")
+            # If flag is False, something is missing (metadata or torrents), acquire lock for scraping
+
             scrape_lock = DistributedLock(media_id)
             lock_acquired = await scrape_lock.acquire()
             waited_for_other_scrape = False

--- a/comet/utils/models.py
+++ b/comet/utils/models.py
@@ -95,6 +95,7 @@ class AppSettings(BaseSettings):
     BACKGROUND_SCRAPER_INTERVAL: Optional[int] = 3600
     BACKGROUND_SCRAPER_MAX_MOVIES_PER_RUN: Optional[int] = 100
     BACKGROUND_SCRAPER_MAX_SERIES_PER_RUN: Optional[int] = 100
+    IGNORE_CACHES_FOR_LIVE_SCRAPING: Optional[bool] = False
 
     @field_validator("INDEXER_MANAGER_TYPE")
     def set_indexer_manager_type(cls, v, values):


### PR DESCRIPTION
## Summary
Adds a new environment variable `IGNORE_CACHES_FOR_LIVE_SCRAPING` that allows forcing fresh scraping from configured scrapers during live requests, bypassing cached metadata and torrents in the database.

## Changes
- Added `IGNORE_CACHES_FOR_LIVE_SCRAPING` boolean setting to `AppSettings` model in `comet/utils/models.py` (defaults to `False`)
- Updated `.env-sample` with documentation for the new parameter
- Modified fast path condition in `comet/api/stream.py` to check the flag before using cached data
- Added logging to indicate when caches are being ignored during live scraping

## Use Case
When `IGNORE_CACHES_FOR_LIVE_SCRAPING=True`, the system will:
1. Skip the fast path that uses cached metadata and torrents
2. Always acquire a scrape lock and fetch fresh data from scrapers
3. Log when caches are being bypassed

This is useful when you want to force-fetch the latest torrents without relying on potentially stale cached data.

## Test Plan
- [ ] Set `IGNORE_CACHES_FOR_LIVE_SCRAPING=False` (default) and verify normal caching behavior works
- [ ] Set `IGNORE_CACHES_FOR_LIVE_SCRAPING=True` and verify fresh scraping occurs even when cached data exists
- [ ] Check logs to confirm appropriate messages are shown in both cases