### PR TITLE
feat: Enhance URL encoding by using `safe=''` in `quote` calls for playback and magnet URIs

### DIFF
--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -443,7 +443,7 @@ async def stream(
                     the_stream["sources"] = torrent["sources"]
             else:
                 the_stream["url"] = (
-                    f"{request.url.scheme}://{request.url.netloc}/{b64config}/playback/{info_hash}/{torrent['fileIndex'] if torrent['cached'] and torrent['fileIndex'] is not None else 'n'}/{quote(title, safe='')}/{result_season}/{result_episode}/{quote(torrent_title, safe='')}"
+                    f"{request.url.scheme}://{request.url.netloc}/{b64config}/playback/{info_hash}/{torrent['fileIndex'] if torrent['cached'] and torrent['fileIndex'] is not None else 'n'}/{quote(quote(title, safe=''), safe='')}/{result_season}/{result_episode}/{quote(torrent_title)}"
                 )
 
             if torrent["cached"]:

--- a/comet/debrid/stremthru.py
+++ b/comet/debrid/stremthru.py
@@ -181,7 +181,7 @@ class StremThru:
         aliases: dict = None,
     ):
         try:
-            magnet_uri = f"magnet:?xt=urn:btih:{hash}&dn={quote(torrent_name, safe='')}"
+            magnet_uri = f"magnet:?xt=urn:btih:{hash}&dn={quote(torrent_name)}"
 
             if sources:
                 for source in sources:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL encoding for non-torrent stream playback to properly handle special characters in titles during URL construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->