### PR TITLE
feat: add DEBRID_CACHE_CHECK_RATIO setting and update availability ch…

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -46,6 +46,7 @@ METADATA_CACHE_TTL=2592000  # 30 days
 TORRENT_CACHE_TTL=1296000  # 15 days - How long before torrents in DB start to be removed. -1 to disable.
 LIVE_TORRENT_CACHE_TTL=1296000  # 15 days - How long before Live is re-queried for a search.
 DEBRID_CACHE_TTL=86400  # 1 day
+DEBRID_CACHE_CHECK_RATIO=0.05  # Minimum ratio (0.05 = 5%) of cached torrents/total torrents required to skip re-checking availability on the debrid service.
 METRICS_CACHE_TTL=60  # 1 minute
 SCRAPE_LOCK_TTL=300  # 5 minutes - Duration for distributed scraping locks
 SCRAPE_WAIT_TIMEOUT=30  # 30 seconds - Max time to wait for other instance to complete scraping

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -363,17 +363,18 @@ async def stream(
         await debrid_service_instance.check_existing_availability(
             torrent_manager.torrents, season, episode
         )
+        cached_count = sum(
+            1 for torrent in torrent_manager.torrents.values() if torrent["cached"]
+        )
+        total_count = len(torrent_manager.torrents)
+
         if (
             (
                 not has_cached_results
-                or sum(
-                    1
-                    for torrent in torrent_manager.torrents.values()
-                    if torrent["cached"]
-                )
-                == 0
+                or cached_count == 0
+                or (cached_count / total_count) < settings.DEBRID_CACHE_CHECK_RATIO
             )
-            and len(torrent_manager.torrents) > 0
+            and total_count > 0
             and debrid_service != "torrent"
         ):
             logger.log("SCRAPER", "🔄 Checking availability on debrid service...")

--- a/comet/core/logger.py
+++ b/comet/core/logger.py
@@ -185,7 +185,7 @@ def log_startup_info(settings):
         replicas = f" - Read Replicas: {settings.DATABASE_READ_REPLICA_URLS}"
     logger.log(
         "COMET",
-        f"Database ({settings.DATABASE_TYPE}): {settings.DATABASE_PATH if settings.DATABASE_TYPE == 'sqlite' else settings.DATABASE_URL} - TTL: metadata={settings.METADATA_CACHE_TTL}s, torrents={settings.TORRENT_CACHE_TTL}s, live_torrents={settings.LIVE_TORRENT_CACHE_TTL}s, debrid={settings.DEBRID_CACHE_TTL}s, metrics={settings.METRICS_CACHE_TTL}s - Startup Cleanup Interval: {settings.DATABASE_STARTUP_CLEANUP_INTERVAL}s{replicas}",
+        f"Database ({settings.DATABASE_TYPE}): {settings.DATABASE_PATH if settings.DATABASE_TYPE == 'sqlite' else settings.DATABASE_URL} - TTL: metadata={settings.METADATA_CACHE_TTL}s, torrents={settings.TORRENT_CACHE_TTL}s, live_torrents={settings.LIVE_TORRENT_CACHE_TTL}s, debrid={settings.DEBRID_CACHE_TTL}s, metrics={settings.METRICS_CACHE_TTL}s - Debrid Ratio: {settings.DEBRID_CACHE_CHECK_RATIO} - Startup Cleanup Interval: {settings.DATABASE_STARTUP_CLEANUP_INTERVAL}s{replicas}",
     )
 
     logger.log(

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -43,6 +43,7 @@ class AppSettings(BaseSettings):
     LIVE_TORRENT_CACHE_TTL: Optional[int] = 1296000  # 15 days
     DEBRID_CACHE_TTL: Optional[int] = 86400  # 1 day
     METRICS_CACHE_TTL: Optional[int] = 60  # 1 minute
+    DEBRID_CACHE_CHECK_RATIO: Optional[float] = 0.0  # 0.0 to 1.0
     SCRAPE_LOCK_TTL: Optional[int] = 300  # 5 minutes
     SCRAPE_WAIT_TIMEOUT: Optional[int] = (
         30  # Max time to wait for other instance to complete


### PR DESCRIPTION
…eck logic

- Introduced DEBRID_CACHE_CHECK_RATIO to control the minimum ratio of cached to total torrents for skipping availability checks on the debrid service.
- Updated the stream endpoint to utilize the new ratio in the availability check logic, enhancing performance by reducing unnecessary checks.
- Enhanced startup logging to include the new DEBRID_CACHE_CHECK_RATIO for better visibility of settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable debrid cache check ratio setting that determines the minimum cached-to-total torrent ratio required to skip re-checking availability on the debrid service. This provides new control over cache-based availability verification behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->