### PR TITLE
Add prometheus metrics, option to cap per-search results, optimizations

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -192,6 +192,12 @@ TORRENT_DISABLED_STREAM_DESCRIPTION=Direct torrent playback is disabled on this 
 TORRENT_DISABLED_STREAM_URL=https://comet.fast # Optional URL included in the placeholder stream response
 
 # ============================== #
+# Stream Result Limits           #
+# ============================== #
+MAX_RESULTS_PER_RESOLUTION_CAP=0 # If >0, overrides client maxResultsPerResolution with this cap
+MAX_STREAM_RESULTS_TOTAL=0 # If >0, hard limit on total streams returned per request
+
+# ============================== #
 # Content Filtering              #
 # ============================== #
 REMOVE_ADULT_CONTENT=False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * add `GUNICORN_PRELOAD_APP` setting to control whether workers inherit a preloaded app or initialize independently
 * add `DATABASE_STARTUP_CLEANUP_INTERVAL` to throttle heavy startup cleanup sweeps across workers
 * add `DISABLE_TORRENT_STREAMS` toggle with customizable placeholder stream metadata
+* expose Prometheus `/metrics` endpoint tracking stream requests per debrid service
+* add server-side stream result caps via `MAX_RESULTS_PER_RESOLUTION_CAP` and `MAX_STREAM_RESULTS_TOTAL`
 
 ## [2.31.0](https://github.com/g0ldyy/comet/compare/v2.30.0...v2.31.0) (2025-12-08)
 

--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -1,0 +1,8 @@
+# Branch Summary
+
+- Added replica-aware database routing (`comet/core/db_router.py`, `comet/core/database.py`, `comet/core/models.py`), letting PostgreSQL deployments list `DATABASE_READ_REPLICA_URLS` so reads can go to replicas while writes remain on the primary, plus a force-primary escape hatch inside maintenance queries.
+- Reduced startup thrash by gating the heavy cleanup sweep behind `DATABASE_STARTUP_CLEANUP_INTERVAL` and persisting anime mapping data in `anime_mapping_cache` tables so most boots load instantly from the DB instead of redownloading (`comet/core/database.py`, `comet/services/anime.py`, env knobs `ANIME_MAPPING_SOURCE`/`ANIME_MAPPING_REFRESH_INTERVAL`).
+- Hardened torrent ingestion and ranking: `TorrentManager` now funnels inserts through an `INSERT ... ON CONFLICT DO UPDATE` helper to quiet duplicate-key races, and ranking/logging paths gained small cleanups (`comet/services/torrent_manager.py`, `comet/services/lock.py`, logging tweaks in `comet/core/log_levels.py`).
+- Added an env-toggle to skip Gunicorn preload (`GUNICORN_PRELOAD_APP`) so large deployments can trade startup cost vs. schema-read requirements (`comet/main.py`, `.env-sample`).
+- Introduced `DISABLE_TORRENT_STREAMS` plus customizable placeholder metadata so operators can block magnet-only usage and show a friendly Stremio message instead (`comet/api/endpoints/stream.py`, `comet/core/models.py`, `.env-sample`).
+- Updated documentation/config samples and changelog to capture the new settings and behavior (`.env-sample`, `CHANGELOG.md`).

--- a/comet/api/app.py
+++ b/comet/api/app.py
@@ -10,6 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
 from comet.api.endpoints import admin, base, config, manifest, playback
+from comet.api.endpoints import metrics as metrics_router
 from comet.api.endpoints import stream as streams_router
 from comet.background_scraper.worker import background_scraper
 from comet.core.database import (cleanup_expired_locks,
@@ -116,4 +117,5 @@ app.include_router(config.router)
 app.include_router(manifest.router)
 app.include_router(admin.router)
 app.include_router(playback.router)
+app.include_router(metrics_router.router)
 app.include_router(streams_router.streams)

--- a/comet/api/endpoints/config.py
+++ b/comet/api/endpoints/config.py
@@ -19,5 +19,6 @@ async def configure(request: Request):
             else "",
             "webConfig": web_config,
             "proxyDebridStream": settings.PROXY_DEBRID_STREAM,
+            "disableTorrentStreams": settings.DISABLE_TORRENT_STREAMS,
         },
     )

--- a/comet/api/endpoints/metrics.py
+++ b/comet/api/endpoints/metrics.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from comet.core.metrics import prom_response
+
+router = APIRouter()
+
+
+@router.get("/metrics")
+async def metrics_endpoint():
+    return prom_response()

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -150,6 +150,10 @@ async def stream(
     if per_resolution_cap > 0:
         client_value = config.get("maxResultsPerResolution") or 0
         if client_value == 0 or client_value > per_resolution_cap:
+            logger.log(
+                "SCRAPER",
+                f"Clamping maxResultsPerResolution from {client_value} to {per_resolution_cap}",
+            )
             config["maxResultsPerResolution"] = per_resolution_cap
 
     record_stream_request(config.get("debridService"))
@@ -449,6 +453,10 @@ async def stream(
         streams_emitted = 0
         for info_hash in torrent_manager.ranked_torrents:
             if max_stream_results > 0 and streams_emitted >= max_stream_results:
+                logger.log(
+                    "SCRAPER",
+                    f"🔪 Truncated streams at {max_stream_results} entries (caps applied)",
+                )
                 break
             torrent = torrents[info_hash]
             rtn_data = torrent["parsed"]

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -7,7 +7,8 @@ from fastapi import APIRouter, BackgroundTasks, Request
 
 from comet.core.config_validation import config_check
 from comet.core.logger import logger
-from comet.core.metrics import record_stream_request
+from comet.core.metrics import (record_non_debrid_stream_request,
+                                record_stream_request)
 from comet.core.models import database, settings, trackers
 from comet.debrid.manager import get_debrid_extension
 from comet.metadata.manager import MetadataScraper
@@ -150,6 +151,9 @@ async def stream(
                 f"Clamping maxResultsPerResolution from {client_value} to {per_resolution_cap}",
             )
             config["maxResultsPerResolution"] = per_resolution_cap
+
+    if config.get("debridService") == "torrent":
+        record_non_debrid_stream_request()
 
     record_stream_request(config.get("debridService"))
 

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -378,6 +378,25 @@ async def stream(
             await scrape_lock.release()
             lock_acquired = False
 
+        if debrid_service != "torrent":
+            is_valid_key = await debrid_service_instance.validate_credentials(
+                session, media_id, media_only_id
+            )
+            if not is_valid_key:
+                logger.log(
+                    "SCRAPER",
+                    f"❌ Invalid API key for {debrid_service}; refusing to serve streams",
+                )
+                return {
+                    "streams": [
+                        {
+                            "name": "[⚠️] Comet",
+                            "description": f"Invalid or unauthorized API key for {debrid_service}. Please update your configuration.",
+                            "url": "https://comet.fast",
+                        }
+                    ]
+                }
+
         await debrid_service_instance.check_existing_availability(
             torrent_manager.torrents, season, episode
         )

--- a/comet/core/database.py
+++ b/comet/core/database.py
@@ -702,7 +702,6 @@ async def _run_startup_cleanup():
             ON CONFLICT (id) DO UPDATE SET last_startup_cleanup = :timestamp
             """,
             {"timestamp": current_time},
-            force_primary=True,
         )
     finally:
         if lock_acquired:

--- a/comet/core/metrics.py
+++ b/comet/core/metrics.py
@@ -1,0 +1,25 @@
+from fastapi import Response
+from prometheus_client import (CONTENT_TYPE_LATEST, CollectorRegistry, Counter,
+                               generate_latest)
+
+# Dedicated registry so we only expose Comet-specific metrics
+_registry = CollectorRegistry()
+
+_stream_requests_total = Counter(
+    "comet_stream_requests_total",
+    "Total number of stream requests grouped by debrid service",
+    ["debrid_service"],
+    registry=_registry,
+)
+
+
+def record_stream_request(debrid_service: str | None):
+    """Increment the stream request counter for the provided service."""
+    label = (debrid_service or "unknown").lower()
+    _stream_requests_total.labels(debrid_service=label).inc()
+
+
+def prom_response() -> Response:
+    """Return a Response containing the current Prometheus metrics payload."""
+    payload = generate_latest(_registry)
+    return Response(content=payload, media_type=CONTENT_TYPE_LATEST)

--- a/comet/core/metrics.py
+++ b/comet/core/metrics.py
@@ -12,11 +12,22 @@ _stream_requests_total = Counter(
     registry=_registry,
 )
 
+_non_debrid_stream_requests_total = Counter(
+    "comet_stream_requests_non_debrid_total",
+    "Total number of stream requests that do not require a user API key",
+    registry=_registry,
+)
+
 
 def record_stream_request(debrid_service: str | None):
     """Increment the stream request counter for the provided service."""
     label = (debrid_service or "unknown").lower()
     _stream_requests_total.labels(debrid_service=label).inc()
+
+
+def record_non_debrid_stream_request():
+    """Increment the counter tracking torrent (non-API) stream requests."""
+    _non_debrid_stream_requests_total.inc()
 
 
 def prom_response() -> Response:

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -106,6 +106,8 @@ class AppSettings(BaseSettings):
         "Direct torrent playback is disabled on this server."
     )
     TORRENT_DISABLED_STREAM_URL: Optional[str] = "https://comet.fast"
+    MAX_RESULTS_PER_RESOLUTION_CAP: Optional[int] = 0
+    MAX_STREAM_RESULTS_TOTAL: Optional[int] = 0
     REMOVE_ADULT_CONTENT: Optional[bool] = False
     BACKGROUND_SCRAPER_ENABLED: Optional[bool] = False
     BACKGROUND_SCRAPER_CONCURRENT_WORKERS: Optional[int] = 1
@@ -165,6 +167,20 @@ class AppSettings(BaseSettings):
         elif isinstance(v, list):
             return [url.rstrip("/") for url in v]
         return v
+
+    @field_validator(
+        "MAX_RESULTS_PER_RESOLUTION_CAP",
+        "MAX_STREAM_RESULTS_TOTAL",
+        mode="before",
+    )
+    def non_negative_int(cls, v):
+        if v is None:
+            return 0
+        try:
+            value = int(v)
+        except (TypeError, ValueError):
+            return 0
+        return value if value >= 0 else 0
 
     def is_scraper_enabled(self, scraper_setting: Union[bool, str], context: str):
         if isinstance(scraper_setting, bool):

--- a/comet/metadata/manager.py
+++ b/comet/metadata/manager.py
@@ -83,9 +83,15 @@ class MetadataScraper:
         )
 
     def normalize_metadata(self, metadata: dict, season: int, episode: int):
-        title, year, year_end = metadata
+        if not metadata:
+            return None
 
-        if title is None:  # metadata retrieving failed
+        try:
+            title, year, year_end = metadata
+        except Exception:
+            return None
+
+        if title is None:
             return None
 
         return {

--- a/comet/services/torrent_manager.py
+++ b/comet/services/torrent_manager.py
@@ -443,10 +443,10 @@ POSTGRES_UPDATE_SET = """
 """
 
 POSTGRES_CONFLICT_MAP = {
-    "series": "torrents_series_both_idx",
-    "season_only": "torrents_season_only_idx",
-    "episode_only": "torrents_episode_only_idx",
-    "none": "torrents_no_season_episode_idx",
+    "series": "(media_id, season, episode, info_hash)",
+    "season_only": "(media_id, season, info_hash)",
+    "episode_only": "(media_id, episode, info_hash)",
+    "none": "(media_id, info_hash)",
 }
 
 _POSTGRES_UPSERT_CACHE: dict[str, str] = {}
@@ -471,7 +471,7 @@ def _get_torrent_upsert_query(conflict_key: str) -> str:
         if constraint not in _POSTGRES_UPSERT_CACHE:
             _POSTGRES_UPSERT_CACHE[constraint] = (
                 TORRENT_INSERT_TEMPLATE
-                + f" ON CONFLICT ON CONSTRAINT {constraint} "
+                + f" ON CONFLICT {constraint} "
                 + POSTGRES_UPDATE_SET
             )
         return _POSTGRES_UPSERT_CACHE[constraint]

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -410,8 +410,10 @@
     </div>
 
     <div class="form-item">
-      <sl-select id="debridService" value="torrent" label="Debrid Service" placeholder="Select debrid service">
+      <sl-select id="debridService" value="{{ 'torrent' if not disableTorrentStreams else 'realdebrid' }}" label="Debrid Service" placeholder="Select debrid service">
+        {% if not disableTorrentStreams %}
         <sl-option value="torrent">Torrent</sl-option>
+        {% endif %}
         <sl-option value="torbox">TorBox</sl-option>
         <sl-option value="debrider">Debrider</sl-option>
         <sl-option value="easydebrid">EasyDebrid</sl-option>

--- a/comet/utils/parsing.py
+++ b/comet/utils/parsing.py
@@ -49,18 +49,31 @@ def default_dump(obj):
         return obj.model_dump()
 
 
+def _safe_int(value, fallback=None):
+    try:
+        if value is None:
+            return fallback
+        text = str(value).strip()
+        if text == "":
+            return fallback
+        return int(text)
+    except (TypeError, ValueError):
+        return fallback
+
+
 def parse_media_id(media_type: str, media_id: str):
     if "kitsu" in media_id:
         info = media_id.split(":")
-
-        if len(info) > 2:
-            return info[1], 1, int(info[2])
-        else:
-            return info[1], 1, None
+        identifier = info[1] if len(info) > 1 else media_id
+        episode = _safe_int(info[2] if len(info) > 2 else None)
+        return identifier, 1, episode
 
     if media_type == "series":
         info = media_id.split(":")
-        return info[0], int(info[1]), int(info[2])
+        identifier = info[0]
+        season = _safe_int(info[1] if len(info) > 1 else None, fallback=1)
+        episode = _safe_int(info[2] if len(info) > 2 else None)
+        return identifier, season, episode
 
     return media_id, None, None
 

--- a/deployment/grafana/comet-stream-requests.json
+++ b/deployment/grafana/comet-stream-requests.json
@@ -1,0 +1,169 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "auto"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "req/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(comet_stream_requests_total[5m])) by (debrid_service)",
+          "legendFormat": "{{debrid_service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stream Requests per Debrid Service (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(comet_stream_requests_total[1h])) by (debrid_service)",
+          "format": "time_series",
+          "legendFormat": "{{debrid_service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests per Debrid Service (last 1h)",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "comet",
+    "streams"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Comet Stream Requests",
+  "uid": "comet-stream-requests",
+  "version": 1,
+  "weekStart": ""
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,5 @@ dependencies = [
     "python-multipart",
     "rank-torrent-name",
     "uvicorn",
+    "prometheus-client",
 ]


### PR DESCRIPTION
Another copilot-driven PR, feel free to disregard :)

This PR includes:

* An option to cap (server-side) the amount of results returned (per-resolution or total)
* Fix conflicts on upserts into DB (may only have affected my old OG database)
* Fail early on for invalid debrid accounts rather than serving cached results which can't be played

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics endpoint to track stream requests by debrid service with accompanying Grafana dashboard
  * Server-side stream result limits via configurable caps per resolution and total
  * Configurable torrent stream disabling with custom placeholder messaging
  * Database read replica routing for improved read performance
  * Startup optimization with persistent anime mapping cache

* **Bug Fixes**
  * Added API key validation for non-torrent debrid services
  * Improved robustness in metadata parsing and torrent duplicate handling

* **Configuration**
  * New environment variables for stream limiting, database replicas, and anime mapping
  * Grafana dashboard asset for monitoring stream request metrics

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->