### PR TITLE
fix: prevent deadlock by sorting locks canonically

### DIFF
--- a/comet/api/endpoints/playback.py
+++ b/comet/api/endpoints/playback.py
@@ -8,6 +8,7 @@ from fastapi.responses import FileResponse, RedirectResponse
 
 from comet.core.config_validation import config_check
 from comet.core.models import database, settings
+from comet.utils.parsing import parse_optional_int
 from comet.debrid.manager import get_debrid
 from comet.metadata.manager import MetadataScraper
 from comet.services.streaming.manager import custom_handle_stream_request
@@ -34,8 +35,8 @@ async def playback(
 ):
     config = config_check(b64config)
 
-    season = int(season) if season != "n" else None
-    episode = int(episode) if episode != "n" else None
+    season = parse_optional_int(season) if season != "n" else None
+    episode = parse_optional_int(episode) if episode != "n" else None
 
     async with aiohttp.ClientSession() as session:
         cached_link = await database.fetch_one(

--- a/comet/utils/parsing.py
+++ b/comet/utils/parsing.py
@@ -49,18 +49,30 @@ def default_dump(obj):
         return obj.model_dump()
 
 
+def parse_optional_int(value: str):
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
 def parse_media_id(media_type: str, media_id: str):
     if "kitsu" in media_id:
         info = media_id.split(":")
 
         if len(info) > 2:
-            return info[1], 1, int(info[2])
+            return info[1], 1, parse_optional_int(info[2])
         else:
             return info[1], 1, None
 
     if media_type == "series":
         info = media_id.split(":")
-        return info[0], int(info[1]), int(info[2])
+        series_id = info[0]
+        season = parse_optional_int(info[1]) if len(info) > 1 else None
+        episode = parse_optional_int(info[2]) if len(info) > 2 else None
+        return series_id, season, episode
 
     return media_id, None, None
 


### PR DESCRIPTION
- Sort batch upserts by lock_key instead of timestamp to ensure deterministic lock acquisition order and prevent cross-transaction deadlocks
- Consolidate _parse_optional_int into comet.utils.parsing
- Simplify _reset_batches logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data parsing and batch processing operations to enhance system reliability and maintainability while preserving existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->