### PR TITLE
feat: add fallback to check watch providers for movie release dates when upcoming release date is unavailable

### DIFF
--- a/comet/metadata/filter.py
+++ b/comet/metadata/filter.py
@@ -54,7 +54,7 @@ class DigitalReleaseFilter:
                 release_date_str = await tmdb.get_upcoming_movie_release_date(tmdb_id)
                 if not release_date_str:
                     # Check watch providers as fallback
-                    has_watch_providers = await tmdb.get_unique_watch_providers(tmdb_id)
+                    has_watch_providers = await tmdb.has_watch_providers(tmdb_id)
                     if has_watch_providers:
                         # Treat as released a long time ago
                         release_date_str = "1970-01-01"

--- a/comet/metadata/tmdb.py
+++ b/comet/metadata/tmdb.py
@@ -78,7 +78,7 @@ class TMDBApi:
             logger.error(f"TMDB: Error converting IMDB ID {imdb_id}: {e}")
             return None
 
-    async def get_unique_watch_providers(self, tmdb_id: str):
+    async def has_watch_providers(self, tmdb_id: str):
         try:
             url = f"{self.base_url}/movie/{tmdb_id}/watch/providers"
             async with self.session.get(url, headers=self.headers) as response:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced movie release status detection by implementing a fallback mechanism that checks watch provider availability from TMDB when standard release date lookups fail. This improves metadata accuracy for films with incomplete release date information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->