### PR TITLE
feat: add configurable `PROXY_DEBRID_STREAM_INACTIVITY_THRESHOLD` setting to enable and refine the cleanup of inactive debrid stream connections

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -213,6 +213,7 @@ PROXY_DEBRID_STREAM_PASSWORD=CHANGE_ME
 PROXY_DEBRID_STREAM_MAX_CONNECTIONS=-1 # -1 to disable connection limits
 PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE=realdebrid
 PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY=CHANGE_ME
+PROXY_DEBRID_STREAM_INACTIVITY_THRESHOLD=300 # Seconds to wait before cleaning up an inactive connection. Set to 0 to disable.
 
 # ============================== #
 # Torrent Stream Policy          #

--- a/comet/core/logger.py
+++ b/comet/core/logger.py
@@ -373,7 +373,7 @@ def log_startup_info(settings):
     )
 
     debrid_stream_proxy_display = (
-        f" - Password: {settings.PROXY_DEBRID_STREAM_PASSWORD} - Max Connections: {settings.PROXY_DEBRID_STREAM_MAX_CONNECTIONS} - Default Debrid Service: {settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE} - Default Debrid API Key: {settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY}"
+        f" - Password: {settings.PROXY_DEBRID_STREAM_PASSWORD} - Max Connections: {settings.PROXY_DEBRID_STREAM_MAX_CONNECTIONS} - Inactivity Threshold: {settings.PROXY_DEBRID_STREAM_INACTIVITY_THRESHOLD}s - Default Debrid Service: {settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE} - Default Debrid API Key: {settings.PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY}"
         if settings.PROXY_DEBRID_STREAM
         else ""
     )

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -114,6 +114,7 @@ class AppSettings(BaseSettings):
     PROXY_DEBRID_STREAM_MAX_CONNECTIONS: Optional[int] = -1
     PROXY_DEBRID_STREAM_DEBRID_DEFAULT_SERVICE: Optional[str] = "realdebrid"
     PROXY_DEBRID_STREAM_DEBRID_DEFAULT_APIKEY: Optional[str] = None
+    PROXY_DEBRID_STREAM_INACTIVITY_THRESHOLD: Optional[int] = 300
     STREMTHRU_URL: Optional[str] = "https://stremthru.13377001.xyz"
     DISABLE_TORRENT_STREAMS: Optional[bool] = False
     TORRENT_DISABLED_STREAM_NAME: Optional[str] = "[INFO] Comet"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable inactivity threshold for automatic connection cleanup in the Debrid Stream Proxy. Users can now customize how long inactive connections remain active before removal (default: 300 seconds). Setting the threshold to 0 disables automatic cleanup. The threshold value is displayed in system logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->