### PR TITLE
feat: refactor live torrent caching to differentiate between displaying existing results and triggering new scrapes, and update default cache TTLs

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -54,8 +54,17 @@ DATABASE_STARTUP_CLEANUP_INTERVAL=3600 # Minimum seconds between heavy startup c
 # Cache Settings (Seconds)       #
 # ============================== #
 METADATA_CACHE_TTL=2592000  # 30 days
-TORRENT_CACHE_TTL=1296000  # 15 days - How long before torrents in DB start to be removed. -1 to disable.
-LIVE_TORRENT_CACHE_TTL=1296000  # 15 days - How long before Live is re-queried for a search.
+
+# TORRENT_CACHE_TTL: Controls when torrents are PERMANENTLY REMOVED from the database.
+#    Set to -1 to disable automatic removal (torrents stay forever).
+TORRENT_CACHE_TTL=2592000  # 30 days
+
+# LIVE_TORRENT_CACHE_TTL: Controls when a NEW LIVE SEARCH is triggered.
+#    If the cache is older than this value, Comet performs a new search to find new torrents.
+#    Important: Old cached torrents are ALWAYS included in results, this only controls refresh frequency.
+#    Set to -1 to never trigger new searches (always use existing cache only).
+LIVE_TORRENT_CACHE_TTL=604800  # 7 days
+
 DEBRID_CACHE_TTL=86400  # 1 day
 DEBRID_CACHE_CHECK_RATIO=0.05  # Minimum ratio (0.05 = 5%) of cached torrents/total torrents required to skip re-checking availability on the debrid service.
 METRICS_CACHE_TTL=60  # 1 minute

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -39,8 +39,8 @@ class AppSettings(BaseSettings):
     DATABASE_READ_REPLICA_URLS: List[str] = Field(default_factory=list)
     DATABASE_STARTUP_CLEANUP_INTERVAL: Optional[int] = 3600
     METADATA_CACHE_TTL: Optional[int] = 2592000  # 30 days
-    TORRENT_CACHE_TTL: Optional[int] = 1296000  # 15 days
-    LIVE_TORRENT_CACHE_TTL: Optional[int] = 1296000  # 15 days
+    TORRENT_CACHE_TTL: Optional[int] = 2592000  # 30 days
+    LIVE_TORRENT_CACHE_TTL: Optional[int] = 604800  # 7 days
     DEBRID_CACHE_TTL: Optional[int] = 86400  # 1 day
     METRICS_CACHE_TTL: Optional[int] = 60  # 1 minute
     DEBRID_CACHE_CHECK_RATIO: Optional[float] = 0.0  # 0.0 to 1.0

--- a/comet/services/orchestration.py
+++ b/comet/services/orchestration.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 
 import aiohttp
 import orjson
@@ -7,7 +6,7 @@ from RTN import DefaultRanking, ParsedData
 
 from comet.core.execution import get_executor
 from comet.core.logger import logger
-from comet.core.models import CometSettingsModel, database, settings
+from comet.core.models import CometSettingsModel, database
 from comet.scrapers.manager import scraper_manager
 from comet.services.filtering import filter_worker
 from comet.services.ranking import rank_worker
@@ -105,14 +104,11 @@ class TorrentManager:
                 WHERE media_id = :media_id
                 AND ((season IS NOT NULL AND season = CAST(:season as INTEGER)) OR (season IS NULL AND CAST(:season as INTEGER) IS NULL))
                 AND (episode IS NULL OR episode = CAST(:episode as INTEGER))
-                AND timestamp + :cache_ttl >= :current_time
             """,
             {
                 "media_id": self.media_only_id,
                 "season": self.season,
                 "episode": self.episode,
-                "cache_ttl": settings.LIVE_TORRENT_CACHE_TTL,
-                "current_time": time.time(),
             },
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Extended torrent cache duration from 15 to 30 days
  * Reduced live torrent cache duration from 15 to 7 days
  * Added new scraping timeout configurations

* **Bug Fixes**
  * Improved cache validation logic for search refreshes
  * Enhanced handling of first-time searches versus cached results

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->