### PR TITLE
Improve year_end filtering logic

### DIFF
--- a/comet/services/orchestration.py
+++ b/comet/services/orchestration.py
@@ -227,6 +227,7 @@ class TorrentManager:
                 self.year_end,
                 self.aliases,
                 self.remove_adult_content,
+                self.media_type,
             )
             for i in range(0, len(new_torrents), chunk_size)
         ]


### PR DESCRIPTION
Remove year filtering logic for series without an ending year

https://github.com/g0ldyy/comet/issues/469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV series filtering logic to handle year validation more accurately, allowing proper filtering when year information is incomplete or uncertain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->