### PR TITLE
Improve scraping on recent releases

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -71,6 +71,23 @@ TORRENT_CACHE_TTL=2592000  # 30 days
 #    Set to -1 to never trigger new searches (always use existing cache only).
 LIVE_TORRENT_CACHE_TTL=604800  # 7 days
 
+# LIVE_TORRENT_CACHE_TTL_RECENT_RELEASE: Shorter TTL for recently released content.
+#    Content released within RECENT_RELEASE_DAYS will use this TTL instead of LIVE_TORRENT_CACHE_TTL.
+#    This allows more frequent refreshes for new releases that may have new torrents appearing.
+#    Leave empty or set to None to disable (uses LIVE_TORRENT_CACHE_TTL for all content).
+LIVE_TORRENT_CACHE_TTL_RECENT_RELEASE=  # Optional: 3600 for 1 hour (disabled by default)
+
+# RECENT_RELEASE_DAYS: Days to consider content "recently released".
+#    Content released within this many days will use LIVE_TORRENT_CACHE_TTL_RECENT_RELEASE.
+#    Leave empty or set to None to disable.
+RECENT_RELEASE_DAYS=  # Optional: 7 for 7 days (disabled by default)
+
+# LIVE_TORRENT_CACHE_TTL_NO_DEBRID: Fallback TTL when no torrents are cached on debrid service.
+#    If release date is unavailable and no torrents are cached on debrid, this shorter TTL is used
+#    to trigger more frequent searches. This helps find new torrents that may be cached on debrid.
+#    Leave empty or set to None to disable.
+LIVE_TORRENT_CACHE_TTL_NO_DEBRID=  # Optional: 3600 for 1 hour (disabled by default)
+
 DEBRID_CACHE_TTL=86400  # 1 day
 DEBRID_CACHE_CHECK_RATIO=0.0  # Minimum ratio (0.5 = 5%) of cached torrents/total torrents required to skip re-checking availability on the debrid service.
 METRICS_CACHE_TTL=60  # 1 minute

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -42,6 +42,9 @@ class AppSettings(BaseSettings):
     METADATA_CACHE_TTL: Optional[int] = 2592000  # 30 days
     TORRENT_CACHE_TTL: Optional[int] = 2592000  # 30 days
     LIVE_TORRENT_CACHE_TTL: Optional[int] = 604800  # 7 days
+    LIVE_TORRENT_CACHE_TTL_RECENT_RELEASE: Optional[int] = None  # TTL for recently released content (None = disabled, uses LIVE_TORRENT_CACHE_TTL)
+    RECENT_RELEASE_DAYS: Optional[int] = None  # Days to consider content "recently released" (None = disabled)
+    LIVE_TORRENT_CACHE_TTL_NO_DEBRID: Optional[int] = None  # TTL fallback when no torrents are cached on debrid (None = disabled)
     DEBRID_CACHE_TTL: Optional[int] = 86400  # 1 day
     METRICS_CACHE_TTL: Optional[int] = 60  # 1 minute
     DEBRID_CACHE_CHECK_RATIO: Optional[float] = 0.0  # 0.0 to 1.0


### PR DESCRIPTION
Improve scraping on recent releases with a more aggressive TTL and fallback to live search if no debrid cached results are returned

https://github.com/g0ldyy/comet/issues/466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added intelligent cache management that adapts Time-To-Live (TTL) based on content release date for recently released items.
  * Introduced configurable fallback cache behavior to trigger more frequent searches when torrents lack debrid caching.
  * Enhanced content availability through dynamic cache refresh logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->