### PR TITLE
refactor: remove 4K resolution option from settings and UI

### DIFF
--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -264,7 +264,6 @@ class CometSettingsModel(SettingsModel):
     model_config = SettingsConfigDict()
 
     resolutions: ResolutionConfig = ResolutionConfig(
-        r4k=True,
         r2160p=True,
         r576p=True,
         r480p=True,

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -428,7 +428,6 @@
           label="Resolutions"
           placeholder="Select resolutions"
         >
-          <sl-option value="r4k">4K DCI - Cinema</sl-option>
           <sl-option value="r2160p">4K UHD - 2160p</sl-option>
           <sl-option value="r1440p">QHD - 1440p</sl-option>
           <sl-option value="r1080p">FHD - 1080p</sl-option>
@@ -773,7 +772,7 @@
             "la": "💃🏻",  // Latino
           };
           let defaultResultFormat = [];
-          const ALL_RESOLUTIONS = ["r4k", "r2160p", "r1440p", "r1080p", "r720p", "r576p", "r480p", "r360p", "r240p", "unknown"];
+          const ALL_RESOLUTIONS = ["r2160p", "r1440p", "r1080p", "r720p", "r576p", "r480p", "r360p", "r240p", "unknown"];
 
           document.addEventListener("DOMContentLoaded", async () => {
             await Promise.allSettled([


### PR DESCRIPTION
- Eliminated the 4K resolution option from the CometSettingsModel and the index.html template.
- Updated the JavaScript constant for available resolutions to reflect the removal, ensuring consistency across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Removed the 4K DCI - Cinema resolution option from the application. Users will no longer see this option available in the resolutions dropdown menu or included in the default configuration settings. All other supported resolutions, including 2160p, 576p, 480p, 360p, and 240p, continue to remain fully available for selection and use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->