### PR TITLE
fix(playback): Fix wrong arg to debrid.generate_download_link()

### DIFF
--- a/comet/api/endpoints/playback.py
+++ b/comet/api/endpoints/playback.py
@@ -49,7 +49,7 @@ async def playback(
     season: str,
     episode: str,
     torrent_name: str,
-    name_query: str = Query(None, alias="name"),
+    name_query: str = Query("", alias="name"),
 ):
     config = config_check(b64config)
 


### PR DESCRIPTION
I'm not sure if this is the appropriate fix, but it worked for me.

Today I decided to setup my own Comet instance as the public elfhosted one seemed to be struggling, and run into this issue. Scraping worked fine, but playback did not. In console I would see:
```
... | ⚠️ WARNING | stremthru.generate_download_link - Exception while getting download link for ...: argument of type 'NoneType' is not iterable
```

Looking into it I found that `torrent_name` was `None` in `stremthru.generate_download_link()`, which was caused by the playback API using `None` as the default value for `name_query` when not provided. This line then failed with said error:

https://github.com/g0ldyy/comet/blob/85fc4566c845ea0bd2f4e52fa9ebe3d5cad3d963/comet/debrid/stremthru.py#L253

It is worth noting that this error seemed to prevent playback from working at all, I was unable to get anything I tried to play, after this simple change everything works perfectly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted default parameter handling in playback functionality to improve consistency when optional query parameters are not provided, ensuring more reliable link generation for playback requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->