### PR TITLE
Add SeaDex scraper with anime mapping integration

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -244,6 +244,8 @@ SCRAPE_TORRENTSDB=False
 
 SCRAPE_PEERFLIX=False
 
+SCRAPE_SEADEX=False # requires ANIME_MAPPING_ENABLED to be True
+
 # ============================== #
 # Debrid Stream Proxy Settings   #
 # ============================== #

--- a/comet/core/logger.py
+++ b/comet/core/logger.py
@@ -454,6 +454,10 @@ def log_startup_info(settings):
     )
     logger.log(
         "COMET",
+        f"SeaDex Scraper: {settings.format_scraper_mode(settings.SCRAPE_SEADEX)}",
+    )
+    logger.log(
+        "COMET",
         f"DMM Scraper: {settings.format_scraper_mode(settings.SCRAPE_DMM)}",
     )
     dmm_ingest_info = (

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -113,6 +113,7 @@ class AppSettings(BaseSettings):
     TORBOX_API_KEY: Optional[str] = None
     SCRAPE_TORRENTSDB: Union[bool, str] = False
     SCRAPE_PEERFLIX: Union[bool, str] = False
+    SCRAPE_SEADEX: Union[bool, str] = False
     CUSTOM_HEADER_HTML: Optional[str] = None
     PROXY_DEBRID_STREAM: Optional[bool] = False
     PROXY_DEBRID_STREAM_PASSWORD: Optional[str] = "".join(

--- a/comet/scrapers/seadex.py
+++ b/comet/scrapers/seadex.py
@@ -1,0 +1,52 @@
+from comet.core.logger import log_scraper_error
+from comet.scrapers.base import BaseScraper
+from comet.scrapers.models import ScrapeRequest
+from comet.services.anime import anime_mapper
+
+
+class SeadexScraper(BaseScraper):
+    BASE_URL = "https://releases.moe"
+
+    async def scrape(self, request: ScrapeRequest):
+        if not anime_mapper.is_loaded():
+            return []
+
+        anilist_id = await anime_mapper.get_anilist_id(request.media_id)
+        if not anilist_id:
+            return []
+
+        torrents = []
+        try:
+            async with self.session.get(
+                f"{self.BASE_URL}/api/collections/entries/records?expand=trs&filter=alID={anilist_id}",
+            ) as response:
+                if response.status != 200:
+                    return []
+                data = await response.json()
+
+            for item in data.get("items", []):
+                for torrent in item.get("expand", {}).get("trs", []):
+                    info_hash = torrent.get("infoHash")
+                    if not info_hash or info_hash == "<redacted>":
+                        continue
+
+                    release_group = torrent.get("releaseGroup")
+                    tracker = f"SeaDex|{release_group}" if release_group else "SeaDex"
+
+                    for idx, file in enumerate(torrent.get("files", [])):
+                        torrents.append(
+                            {
+                                "title": file["name"],
+                                "infoHash": info_hash,
+                                "fileIndex": idx,
+                                "seeders": None,
+                                "size": file["length"],
+                                "tracker": tracker,
+                                "sources": [],
+                            }
+                        )
+
+        except Exception as e:
+            log_scraper_error("Seadex", self.BASE_URL, request.media_id, e)
+
+        return torrents


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SeaDex scraper now integrated to process anime collections and generate torrent metadata including infoHash values, file listings, file sizes, and tracker information from releases
  * Media ID format support extended to recognize IMDB (tt-prefixed) and Kitsu identifier formats for anime mapping resolution

* **Chores**
  * Added SCRAPE_SEADEX configuration toggle (requires ANIME_MAPPING_ENABLED)
  * Added SeaDex scraper startup logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->