### PR TITLE
refactor: standardize type hints with `typing` module

### DIFF
--- a/kodi/plugin.video.comet/addon.xml
+++ b/kodi/plugin.video.comet/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.comet" version="1.0.0" name="Comet" provider-name="Goldy">
+<addon id="plugin.video.comet" version="1.0.1" name="Comet" provider-name="Goldy">
     <requires>
         <import addon="xbmc.python" version="3.0.1" />
         <import addon="xbmc.metadata" version="2.1.0" />

--- a/kodi/plugin.video.comet/lib/router.py
+++ b/kodi/plugin.video.comet/lib/router.py
@@ -1,6 +1,7 @@
 import json
 import re
 import sys
+from typing import Optional, Tuple
 from urllib import parse
 
 import xbmc
@@ -29,7 +30,7 @@ _TAGLINE_KEYS = (
     "trackerInfo",
     "languagesInfo",
 )
-_PROVIDER_CONTEXT_CACHE: tuple[str, str] | None = None
+_PROVIDER_CONTEXT_CACHE: Optional[Tuple[str, str]] = None
 
 
 def _compose_url(base_url: str, path: str):
@@ -114,7 +115,7 @@ def _parse_release_year(release_info):
     return int(match.group()) if match else None
 
 
-def _upgrade_metahub_url(url: str | None):
+def _upgrade_metahub_url(url: Optional[str]):
     if url and "/poster/small/" in url:
         return url.replace("/poster/small/", "/poster/medium/")
     return url or None
@@ -151,7 +152,9 @@ def _set_video_tags(tags, meta: dict, title: str):
         tags.setGenres(genres)
 
 
-def _build_art(primary: str | None, poster: str | None, background: str | None):
+def _build_art(
+    primary: Optional[str], poster: Optional[str], background: Optional[str]
+):
     art = {}
     if primary:
         art["thumb"] = primary
@@ -211,7 +214,7 @@ def _set_episode_art(list_item, video: dict, meta: dict):
         list_item.setArt(art)
 
 
-def _set_season_art(list_item, meta: dict, season_thumbnail: str | None):
+def _set_season_art(list_item, meta: dict, season_thumbnail: Optional[str]):
     season_thumb = _upgrade_metahub_url(season_thumbnail)
     poster = _upgrade_metahub_url(meta.get("poster"))
     background = _upgrade_metahub_url(meta.get("background")) or poster
@@ -225,7 +228,7 @@ def _stream_tagline(video_info: dict):
     return " | ".join(part for part in parts if part)
 
 
-def _add_directory_items(items: list, total_items: int | None = None):
+def _add_directory_items(items: list, total_items: Optional[int] = None):
     if not items:
         return
     xbmcplugin.addDirectoryItems(

--- a/kodi/plugin.video.comet/lib/utils.py
+++ b/kodi/plugin.video.comet/lib/utils.py
@@ -1,4 +1,5 @@
 import sys
+from typing import List
 from urllib import parse
 
 import requests
@@ -51,7 +52,7 @@ def fetch_data(url: str):
 
 def convert_info_hash_to_magnet(
     info_hash: str,
-    trackers: list[str],
+    trackers: List[str],
     display_name: str = "",
 ):
     magnet_parts = [f"magnet:?xt=urn:btih:{info_hash.strip()}"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped addon version to 1.0.1
  * Internal code quality improvements for Python compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->