### PR TITLE
Add URL-level scrape mode suffixes for execution control

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -172,8 +172,10 @@ DOWNLOAD_GENERIC_TRACKERS=False # Enable downloading generic trackers list at st
 # Multi-Instance Scraping Support:
 # - Single URL: Use a simple string for one instance (default behavior)
 # - Multiple URLs: Use JSON array format for multiple instances
+# - Optional per-instance mode: append :both, :live, or :background to each URL
 # - Example single: COMET_URL=https://comet.feels.legal
 # - Example multi: COMET_URL='["https://comet1.example.com", "https://comet2.example.com"]'
+# - Example mixed: BITMAGNET_URL='["http://bitmagnet:3333:both", "https://public-bitmagnet.example.com:live"]'
 #
 # Scraper Context Modes:
 # Each SCRAPE_* setting can control when scrapers are used:
@@ -237,6 +239,7 @@ BITMAGNET_MAX_CONCURRENT_PAGES=5
 BITMAGNET_MAX_OFFSET=15000 # Maximum number of entries to scrape
 # Multi-instance example:
 # BITMAGNET_URL='["https://bitmagnet1.example.com", "https://bitmagnet2.example.com"]'
+# BITMAGNET_URL='["http://bitmagnet:3333:both", "https://bitmagnetfortheweebs.midnightignite.me:live"]'
 
 SCRAPE_TORRENTIO=False
 TORRENTIO_URL=https://torrentio.strem.fun

--- a/comet/scrapers/manager.py
+++ b/comet/scrapers/manager.py
@@ -11,7 +11,9 @@ from comet.scrapers.base import BaseScraper
 from comet.scrapers.models import ScrapeRequest
 from comet.services.anime import anime_mapper
 from comet.utils.network_manager import network_manager
-from comet.utils.parsing import associate_urls_credentials
+from comet.utils.parsing import (associate_urls_credentials,
+                                 parse_url_scrape_mode,
+                                 url_mode_matches_context)
 
 ANIME_ONLY_SETTING_BY_SCRAPER = {
     "NyaaScraper": "NYAA_ANIME_ONLY",
@@ -57,6 +59,13 @@ class ScraperManager:
             logger.warning(f"Scraper {name} failed: {e}")  # todo: better error handling
             return name, []
 
+    @staticmethod
+    def _resolve_url_for_context(url: str, context: str):
+        parsed_url, mode = parse_url_scrape_mode(url)
+        if not url_mode_matches_context(mode, context):
+            return None
+        return parsed_url
+
     async def scrape_all(self, request: ScrapeRequest):
         tasks = []
         is_anime_content = None
@@ -94,11 +103,18 @@ class ScraperManager:
                     settings.MEDIAFUSION_URL, settings.MEDIAFUSION_API_PASSWORD
                 )
                 if url_credentials_pairs:
-                    for i, (url, password) in enumerate(url_credentials_pairs):
-                        scraper = scraper_class(self, client, url, password)
+                    active_instance_count = 0
+                    for url, password in url_credentials_pairs:
+                        parsed_url = self._resolve_url_for_context(url, request.context)
+                        if parsed_url is None:
+                            continue
+                        active_instance_count += 1
+                        scraper = scraper_class(self, client, parsed_url, password)
                         tasks.append(
                             self._scrape_wrapper(
-                                f"{scraper_name_clean} #{i + 1}", scraper, request
+                                f"{scraper_name_clean} #{active_instance_count}",
+                                scraper,
+                                request,
                             )
                         )
 
@@ -107,11 +123,18 @@ class ScraperManager:
                     settings.AIOSTREAMS_URL, settings.AIOSTREAMS_USER_UUID_AND_PASSWORD
                 )
                 if url_credentials_pairs:
-                    for i, (url, credentials) in enumerate(url_credentials_pairs):
-                        scraper = scraper_class(self, client, url, credentials)
+                    active_instance_count = 0
+                    for url, credentials in url_credentials_pairs:
+                        parsed_url = self._resolve_url_for_context(url, request.context)
+                        if parsed_url is None:
+                            continue
+                        active_instance_count += 1
+                        scraper = scraper_class(self, client, parsed_url, credentials)
                         tasks.append(
                             self._scrape_wrapper(
-                                f"{scraper_name_clean} #{i + 1}", scraper, request
+                                f"{scraper_name_clean} #{active_instance_count}",
+                                scraper,
+                                request,
                             )
                         )
 
@@ -125,11 +148,18 @@ class ScraperManager:
                     urls = [urls]
 
                 if urls:
-                    for i, url in enumerate(urls):
-                        scraper = scraper_class(self, client, url)
+                    active_instance_count = 0
+                    for url in urls:
+                        parsed_url = self._resolve_url_for_context(url, request.context)
+                        if parsed_url is None:
+                            continue
+                        active_instance_count += 1
+                        scraper = scraper_class(self, client, parsed_url)
                         tasks.append(
                             self._scrape_wrapper(
-                                f"{scraper_name_clean} #{i + 1}", scraper, request
+                                f"{scraper_name_clean} #{active_instance_count}",
+                                scraper,
+                                request,
                             )
                         )
                 else:

--- a/comet/utils/parsing.py
+++ b/comet/utils/parsing.py
@@ -1,4 +1,9 @@
+from functools import lru_cache
+
 from RTN import ParsedData
+
+SCRAPE_URL_MODE_BOTH = "both"
+SCRAPE_URL_MODES = frozenset((SCRAPE_URL_MODE_BOTH, "live", "background"))
 
 
 def ensure_multi_language(parsed: ParsedData):
@@ -105,6 +110,21 @@ def parsed_matches_target(
     if parsed.episodes and episode not in parsed.episodes:
         return False
     return True
+
+
+@lru_cache(maxsize=1024)
+def parse_url_scrape_mode(url: str):
+    normalized = url.strip().rstrip("/")
+    base_url, separator, mode = normalized.rpartition(":")
+    if separator:
+        lowered_mode = mode.lower()
+        if lowered_mode in SCRAPE_URL_MODES:
+            return base_url.rstrip("/"), lowered_mode
+    return normalized, SCRAPE_URL_MODE_BOTH
+
+
+def url_mode_matches_context(mode: str, context: str):
+    return mode == SCRAPE_URL_MODE_BOTH or mode == context
 
 
 def associate_urls_credentials(urls, credentials):

--- a/docs/advanced/02-configuration-model.md
+++ b/docs/advanced/02-configuration-model.md
@@ -14,6 +14,7 @@ Practical rule:
 `AppSettings` applies normalization and compatibility logic:
 
 - URL settings have trailing `/` removed.
+- URL list entries may include an instance mode suffix (`:live`, `:background`, `:both`).
 - `DATABASE_TYPE` aliases (`postgres`, `pgsql`, `sqlite3`, etc.) are normalized.
 - Scraper context mode supports `true/both/live/background/false`.
 - `PUBLIC_API_TOKEN` and `PUBLIC_API_TOKEN_FILE` support auto-generation when API protection is enabled.

--- a/docs/advanced/04-scrapers-background-and-dmm.md
+++ b/docs/advanced/04-scrapers-background-and-dmm.md
@@ -11,6 +11,14 @@ Enablement is controlled by `SCRAPE_*` settings with context modes:
 - `background`
 - `false`
 
+For URL-based scrapers, each URL can also override context with a suffix:
+
+- `:both` (default when omitted)
+- `:live`
+- `:background`
+
+Effective execution is the intersection of scraper-level mode (`SCRAPE_*`) and URL-level mode.
+
 Anime-only gates are enforced for specific scrapers (`NYAA_ANIME_ONLY`, `ANIMETOSHO_ANIME_ONLY`, `SEADEX_ANIME_ONLY`, `NEKOBT_ANIME_ONLY`).
 
 ## Indexer Manager (Jackett/Prowlarr)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-instance mode suffixes to scraper URLs, allowing fine-grained control over scraper execution based on context (:both, :live, :background).

* **Documentation**
  * Updated configuration and scraper documentation to explain mode suffix syntax and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->