### PR TITLE
feat: Per-user custom catalog addon support

### DIFF
--- a/comet/api/app.py
+++ b/comet/api/app.py
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
 from comet.api.endpoints import (admin, base, chilllink, cometnet, cometnet_ui,
-                                 config, debrid_sync, kodi, manifest, playback)
+                                 config, custom_catalog, debrid_sync, kodi, manifest, playback)
 from comet.api.endpoints import stream as streams_router
 from comet.background_scraper.worker import background_scraper
 from comet.cometnet.manager import init_cometnet_service
@@ -80,7 +80,8 @@ async def lifespan(app: FastAPI):
     if settings.BACKGROUND_SCRAPER_ENABLED:
         background_scraper.clear_finished_task()
         if not background_scraper.task:
-            background_scraper.task = asyncio.create_task(background_scraper.start())
+            background_scraper.task = asyncio.create_task(
+                background_scraper.start())
 
     # Start DMM Ingester if enabled
     dmm_ingester_task = None
@@ -108,8 +109,10 @@ async def lifespan(app: FastAPI):
 
         # Set callback to save torrents received from the network
         cometnet_service.set_save_torrent_callback(save_torrent_from_network)
-        cometnet_service.set_check_torrent_exists_callback(check_torrent_exists)
-        cometnet_service.set_check_torrents_exist_callback(check_torrents_exist)
+        cometnet_service.set_check_torrent_exists_callback(
+            check_torrent_exists)
+        cometnet_service.set_check_torrents_exist_callback(
+            check_torrents_exist)
         await cometnet_service.start()
 
     # Start indexer manager
@@ -231,6 +234,7 @@ stremio_routers = (
     debrid_sync.router,
     streams_router.streams,
     chilllink.router,
+    custom_catalog.router,
 )
 
 for stremio_router in stremio_routers:

--- a/comet/api/endpoints/custom_catalog.py
+++ b/comet/api/endpoints/custom_catalog.py
@@ -35,7 +35,7 @@ async def _fetch_json(url: str, timeout: int = 15) -> Optional[dict]:
         session = await http_client_manager.get_session()
         async with session.get(
             url,
-            timeout=__import__("aiohttp").ClientTimeout(total=timeout),
+            timeout=aiohttp.ClientTimeout(total=timeout),
             headers={"Accept": "application/json"},
         ) as resp:
             if resp.status == 200:
@@ -46,8 +46,9 @@ async def _fetch_json(url: str, timeout: int = 15) -> Optional[dict]:
             try:
                 text = await resp.text()
                 logger.warning(f"Custom catalog err body: {text}")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(
+                    f"Custom catalog: failed reading response body: {e}", exc_info=True)
     except asyncio.TimeoutError:
         logger.warning(f"Custom catalog: timeout fetching {url}")
     except Exception as e:
@@ -101,7 +102,7 @@ async def resolve_custom_prefix_to_imdb(
     meta = data.get("meta") or {}
     logger.info(f"Custom catalog: received meta keys = {list(meta.keys())}")
 
-    # Try common locations for IMDB ID – adjust to actual API response structure
+    # Try common locations for IMDB ID - adjust to actual API response structure
     for candidate in [
         meta.get("imdbId"),
         meta.get("imdb"),
@@ -133,7 +134,7 @@ def _parse_catalog_id(catalog_id: str) -> Optional[tuple]:
         underscore_pos = rest.index("_")
         idx = int(rest[:underscore_pos])
         remainder = rest[underscore_pos + 1:]
-        # remainder is "{prefix}_{type}" – split at the *last* underscore
+        # remainder is "{prefix}_{type}" - split at the *last* underscore
         # because prefix itself may not contain underscores and type is
         # always the rightmost segment.
         last_underscore = remainder.rfind("_")

--- a/comet/api/endpoints/custom_catalog.py
+++ b/comet/api/endpoints/custom_catalog.py
@@ -14,7 +14,6 @@ to convert custom-prefix IDs (e.g. csfd12345) into IMDB IDs.
 
 import asyncio
 import ipaddress
-import socket
 from urllib.parse import urlparse
 from typing import Optional
 
@@ -46,7 +45,7 @@ _PRIVATE_NETWORKS = [
 ]
 
 
-def _is_safe_url(url: str) -> bool:
+async def _is_safe_url(url: str) -> bool:
     """
     Return True if the URL resolves only to public, non-private addresses.
     Blocks SSRF targets: loopback, private ranges, link-local, multicast, etc.
@@ -75,8 +74,10 @@ def _is_safe_url(url: str) -> bool:
         except ValueError:
             pass  # hostname is a name, not an IP literal
 
-        # Resolve hostname and check ALL returned addresses (prevents mixed-DNS bypass)
-        all_addrs = socket.getaddrinfo(hostname, None)
+        # Resolve hostname and check ALL returned addresses (prevents mixed-DNS bypass).
+        # Uses the async resolver so we don't block the event loop.
+        loop = asyncio.get_running_loop()
+        all_addrs = await loop.getaddrinfo(hostname, None)
         for record in all_addrs:
             ip_str = record[4][0]
             try:
@@ -107,7 +108,7 @@ async def _fetch_json(url: str, timeout: int = 15) -> Optional[dict]:
     parsed = urlparse(url)
     host_label = parsed.hostname or "<unknown>"
 
-    if not _is_safe_url(url):
+    if not await _is_safe_url(url):
         logger.warning(
             f"Custom catalog: blocked request to private/unsafe host {host_label!r}"
         )
@@ -168,7 +169,7 @@ def _safe_get(d: object, *keys: str) -> object:
 async def resolve_custom_prefix_to_imdb(
     media_type: str,
     media_id: str,
-    custom_catalogs: list,
+    custom_catalogs: Optional[list],
     timeout: int = 15,
 ) -> tuple[Optional[str], Optional[dict]]:
     """
@@ -256,9 +257,8 @@ def _parse_catalog_id(catalog_id: str) -> Optional[tuple]:
                 f"Custom catalog: rejected negative catalog index {idx}")
             return None
         remainder = rest[underscore_pos + 1:]
-        # remainder is "{prefix}_{type}" - split at the *last* underscore
-        # because prefix itself may not contain underscores and type is
-        # always the rightmost segment.
+        # remainder is "{prefix}_{type}" - split at the *last* underscore so the
+        # rightmost segment is the type; the prefix may itself contain underscores.
         last_underscore = remainder.rfind("_")
         if last_underscore < 0:
             return None

--- a/comet/api/endpoints/custom_catalog.py
+++ b/comet/api/endpoints/custom_catalog.py
@@ -48,38 +48,51 @@ _PRIVATE_NETWORKS = [
 
 def _is_safe_url(url: str) -> bool:
     """
-    Return True if the URL resolves to a public, non-private address.
+    Return True if the URL resolves only to public, non-private addresses.
     Blocks SSRF targets: loopback, private ranges, link-local, multicast, etc.
+    Also validates that the scheme is http or https.
     """
     try:
         parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            logger.warning(
+                f"Custom catalog: rejected URL with unsupported scheme {parsed.scheme!r}"
+            )
+            return False
         hostname = parsed.hostname
         if not hostname:
             return False
 
+        def _addr_is_blocked(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+            if addr.is_multicast or addr.is_unspecified or addr.is_reserved:
+                return True
+            return any(addr in net for net in _PRIVATE_NETWORKS)
+
         # Reject raw IP literals in private ranges without DNS resolution
         try:
             addr = ipaddress.ip_address(hostname)
-            for net in _PRIVATE_NETWORKS:
-                if addr in net:
-                    return False
-            if addr.is_multicast or addr.is_unspecified or addr.is_reserved:
-                return False
-            return True
+            return not _addr_is_blocked(addr)
         except ValueError:
             pass  # hostname is a name, not an IP literal
 
-        # Resolve hostname to IP and check
-        resolved_ip = socket.getaddrinfo(hostname, None)[0][4][0]
-        addr = ipaddress.ip_address(resolved_ip)
-        for net in _PRIVATE_NETWORKS:
-            if addr in net:
+        # Resolve hostname and check ALL returned addresses (prevents mixed-DNS bypass)
+        all_addrs = socket.getaddrinfo(hostname, None)
+        for record in all_addrs:
+            ip_str = record[4][0]
+            try:
+                addr = ipaddress.ip_address(ip_str)
+                if _addr_is_blocked(addr):
+                    logger.warning(
+                        f"Custom catalog: SSRF block - {hostname!r} "
+                        f"resolved to blocked address {ip_str!r}"
+                    )
+                    return False
+            except ValueError:
+                # Unexpected non-IP result from getaddrinfo; treat as unsafe
                 logger.warning(
-                    f"Custom catalog: SSRF block - {hostname!r} resolved to private range"
+                    f"Custom catalog: SSRF block - could not parse resolved address {ip_str!r}"
                 )
                 return False
-        if addr.is_multicast or addr.is_unspecified or addr.is_reserved:
-            return False
         return True
     except Exception as e:
         logger.warning(f"Custom catalog: URL safety check failed: {e}")
@@ -140,8 +153,17 @@ async def _fetch_json(url: str, timeout: int = 15) -> Optional[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Helper: resolve custom-prefix ID -> IMDB ID
+# Safe nested dict accessor
 # ---------------------------------------------------------------------------
+
+def _safe_get(d: object, *keys: str) -> object:
+    """Traverse nested dicts safely; returns None if any step is missing or not a dict."""
+    for key in keys:
+        if not isinstance(d, dict):
+            return None
+        d = d.get(key)
+    return d
+
 
 async def resolve_custom_prefix_to_imdb(
     media_type: str,
@@ -202,10 +224,10 @@ async def resolve_custom_prefix_to_imdb(
         meta.get("imdbId"),
         meta.get("imdb"),
         meta.get("tt"),
-        (meta.get("externalIds") or {}).get("imdb"),
-        (meta.get("externalIds") or {}).get("imdbId"),
-        (meta.get("filmOverviewOut") or {}).get("imdbId"),
-        ((meta.get("filmOverviewOut") or {}).get("externalIds") or {}).get("imdb"),
+        _safe_get(meta, "externalIds", "imdb"),
+        _safe_get(meta, "externalIds", "imdbId"),
+        _safe_get(meta, "filmOverviewOut", "imdbId"),
+        _safe_get(meta, "filmOverviewOut", "externalIds", "imdb"),
     ]:
         if candidate and str(candidate).startswith("tt"):
             return str(candidate), meta
@@ -257,13 +279,13 @@ async def _handle_catalog(
 ) -> JSONResponse:
     parsed = _parse_catalog_id(catalog_id)
     if not parsed:
-        return JSONResponse({"metas": []})
+        return JSONResponse({"metas": []}, headers={"Access-Control-Allow-Origin": "*"})
 
     idx, prefix, _declared_type = parsed
 
     config = config_check(b64config, strict_b64config=False)
     if not config:
-        return JSONResponse({"metas": []})
+        return JSONResponse({"metas": []}, headers={"Access-Control-Allow-Origin": "*"})
 
     custom_catalogs = config.get("customCatalogs") or []
     # Reject both out-of-range and negative indices (negative already caught above,
@@ -272,14 +294,14 @@ async def _handle_catalog(
         logger.warning(
             f"Custom catalog: index {idx} out of range (len={len(custom_catalogs)})"
         )
-        return JSONResponse({"metas": []})
+        return JSONResponse({"metas": []}, headers={"Access-Control-Allow-Origin": "*"})
 
     entry = custom_catalogs[idx]
     base_url = (entry.get("url") or "").strip().rstrip("/")
     entry_prefix = (entry.get("prefix") or "").strip()
 
     if not base_url or not entry_prefix:
-        return JSONResponse({"metas": []})
+        return JSONResponse({"metas": []}, headers={"Access-Control-Allow-Origin": "*"})
 
     # Safety: verify prefix still matches what is stored in user config
     if entry_prefix != prefix:
@@ -287,7 +309,7 @@ async def _handle_catalog(
             f"Custom catalog: prefix mismatch: config has {entry_prefix!r}, "
             f"catalog_id implies {prefix!r}"
         )
-        return JSONResponse({"metas": []})
+        return JSONResponse({"metas": []}, headers={"Access-Control-Allow-Origin": "*"})
 
     # The original catalog ID on the remote addon is constructed from the prefix
     # and the requested catalog type.  The manifest endpoint registers catalogs

--- a/comet/api/endpoints/custom_catalog.py
+++ b/comet/api/endpoints/custom_catalog.py
@@ -13,6 +13,9 @@ to convert custom-prefix IDs (e.g. csfd12345) into IMDB IDs.
 """
 
 import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlparse
 from typing import Optional
 
 import aiohttp
@@ -27,10 +30,76 @@ router = APIRouter()
 
 
 # ---------------------------------------------------------------------------
+# SSRF protection helpers
+# ---------------------------------------------------------------------------
+
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fe80::/10"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+
+def _is_safe_url(url: str) -> bool:
+    """
+    Return True if the URL resolves to a public, non-private address.
+    Blocks SSRF targets: loopback, private ranges, link-local, multicast, etc.
+    """
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Reject raw IP literals in private ranges without DNS resolution
+        try:
+            addr = ipaddress.ip_address(hostname)
+            for net in _PRIVATE_NETWORKS:
+                if addr in net:
+                    return False
+            if addr.is_multicast or addr.is_unspecified or addr.is_reserved:
+                return False
+            return True
+        except ValueError:
+            pass  # hostname is a name, not an IP literal
+
+        # Resolve hostname to IP and check
+        resolved_ip = socket.getaddrinfo(hostname, None)[0][4][0]
+        addr = ipaddress.ip_address(resolved_ip)
+        for net in _PRIVATE_NETWORKS:
+            if addr in net:
+                logger.warning(
+                    f"Custom catalog: SSRF block - {hostname!r} resolved to private range"
+                )
+                return False
+        if addr.is_multicast or addr.is_unspecified or addr.is_reserved:
+            return False
+        return True
+    except Exception as e:
+        logger.warning(f"Custom catalog: URL safety check failed: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Internal HTTP helper
 # ---------------------------------------------------------------------------
 
 async def _fetch_json(url: str, timeout: int = 15) -> Optional[dict]:
+    parsed = urlparse(url)
+    host_label = parsed.hostname or "<unknown>"
+
+    if not _is_safe_url(url):
+        logger.warning(
+            f"Custom catalog: blocked request to private/unsafe host {host_label!r}"
+        )
+        return None
+
     try:
         session = await http_client_manager.get_session()
         async with session.get(
@@ -40,24 +109,38 @@ async def _fetch_json(url: str, timeout: int = 15) -> Optional[dict]:
         ) as resp:
             if resp.status == 200:
                 data = await resp.json(content_type=None)
-                logger.info(f"Custom catalog: fetch success for {url}")
+                if not isinstance(data, dict):
+                    logger.warning(
+                        f"Custom catalog: unexpected response type {type(data).__name__!r} "
+                        f"from {host_label!r}"
+                    )
+                    return None
+                logger.info(
+                    f"Custom catalog: fetch success from {host_label!r}")
                 return data
-            logger.warning(f"Custom catalog: HTTP {resp.status} for {url}")
+            logger.warning(
+                f"Custom catalog: HTTP {resp.status} from {host_label!r}"
+            )
             try:
-                text = await resp.text()
-                logger.warning(f"Custom catalog err body: {text}")
+                body_snippet = (await resp.text())[:200]
+                logger.debug(
+                    f"Custom catalog: error body snippet from {host_label!r}: {body_snippet!r}"
+                )
             except Exception as e:
                 logger.debug(
-                    f"Custom catalog: failed reading response body: {e}", exc_info=True)
+                    f"Custom catalog: failed reading response body from {host_label!r}: {e}",
+                    exc_info=True,
+                )
     except asyncio.TimeoutError:
-        logger.warning(f"Custom catalog: timeout fetching {url}")
+        logger.warning(f"Custom catalog: timeout fetching from {host_label!r}")
     except Exception as e:
-        logger.warning(f"Custom catalog: error fetching {url}: {e}")
+        logger.warning(
+            f"Custom catalog: error fetching from {host_label!r}: {e}")
     return None
 
 
 # ---------------------------------------------------------------------------
-# Helper: resolve custom-prefix ID → IMDB ID
+# Helper: resolve custom-prefix ID -> IMDB ID
 # ---------------------------------------------------------------------------
 
 async def resolve_custom_prefix_to_imdb(
@@ -68,7 +151,7 @@ async def resolve_custom_prefix_to_imdb(
 ) -> tuple[Optional[str], Optional[dict]]:
     """
     For a media_id whose prefix matches one of the user's customCatalogs,
-    call /meta/{type}/{media_id}.json on the corresponding addon URL and
+    call /meta/{type}/{base_id}.json on the corresponding addon URL and
     attempt to extract an IMDB ID from the response.
 
     Returns ``(imdb_id, meta_dict)``. If IMDB ID is not found, imdb_id is None,
@@ -84,7 +167,8 @@ async def resolve_custom_prefix_to_imdb(
 
     if not matched_url:
         logger.warning(
-            f"Custom catalog plugin logic: NO MATCHED URL for {media_id}")
+            f"Custom catalog: no matched addon URL for media_id prefix in {media_id!r}"
+        )
         return None, None
 
     # Stremio uses IDs like prefix123:1:2 for series streams, but custom catalogs
@@ -92,15 +176,26 @@ async def resolve_custom_prefix_to_imdb(
     base_id = media_id.split(":")[0]
 
     meta_url = f"{matched_url}/meta/{media_type}/{base_id}.json"
-    logger.info(f"Custom catalog: requesting IMDB resolution from {meta_url}")
+    parsed_host = urlparse(meta_url).hostname or "<unknown>"
+    logger.info(
+        f"Custom catalog: requesting IMDB resolution from {parsed_host!r}")
     data = await _fetch_json(meta_url, timeout)
     if not data:
         logger.warning(
-            f"Custom catalog: fetch returned empty/none for {meta_url}")
+            f"Custom catalog: fetch returned empty/none from {parsed_host!r}"
+        )
         return None, None
 
+    # data is validated to be a dict by _fetch_json
     meta = data.get("meta") or {}
-    logger.info(f"Custom catalog: received meta keys = {list(meta.keys())}")
+    if not isinstance(meta, dict):
+        logger.warning(
+            f"Custom catalog: 'meta' field is not a dict (got {type(meta).__name__!r}) "
+            f"from {parsed_host!r}"
+        )
+        return None, None
+
+    logger.info(f"Custom catalog: received meta keys = {list(meta.keys())!r}")
 
     # Try common locations for IMDB ID - adjust to actual API response structure
     for candidate in [
@@ -126,6 +221,7 @@ def _parse_catalog_id(catalog_id: str) -> Optional[tuple]:
     """
     Parse a catalog ID of the form ``cstm{idx}_{prefix}_{type}``.
     Returns ``(idx, prefix, catalog_type)`` or ``None``.
+    Rejects negative or obviously out-of-range idx values.
     """
     if not catalog_id.startswith("cstm"):
         return None
@@ -133,6 +229,10 @@ def _parse_catalog_id(catalog_id: str) -> Optional[tuple]:
     try:
         underscore_pos = rest.index("_")
         idx = int(rest[:underscore_pos])
+        if idx < 0:
+            logger.warning(
+                f"Custom catalog: rejected negative catalog index {idx}")
+            return None
         remainder = rest[underscore_pos + 1:]
         # remainder is "{prefix}_{type}" - split at the *last* underscore
         # because prefix itself may not contain underscores and type is
@@ -166,9 +266,12 @@ async def _handle_catalog(
         return JSONResponse({"metas": []})
 
     custom_catalogs = config.get("customCatalogs") or []
-    if idx >= len(custom_catalogs):
+    # Reject both out-of-range and negative indices (negative already caught above,
+    # but guard again against races/edge cases in case of direct calls)
+    if idx < 0 or idx >= len(custom_catalogs):
         logger.warning(
-            f"Custom catalog: index {idx} out of range for user config")
+            f"Custom catalog: index {idx} out of range (len={len(custom_catalogs)})"
+        )
         return JSONResponse({"metas": []})
 
     entry = custom_catalogs[idx]

--- a/comet/api/endpoints/custom_catalog.py
+++ b/comet/api/endpoints/custom_catalog.py
@@ -1,0 +1,227 @@
+"""
+Custom catalog proxy endpoints.
+
+Handles:
+- GET /{b64config}/catalog/{type}/{id}.json
+- GET /{b64config}/catalog/{type}/{id}/{extra:path}.json
+
+Catalog IDs with the pattern `cstm{idx}_{prefix}_{type}` are proxied
+to the user-configured custom catalog addon URL.
+
+Also exposes a helper `resolve_custom_prefix_to_imdb` used by stream.py
+to convert custom-prefix IDs (e.g. csfd12345) into IMDB IDs.
+"""
+
+import asyncio
+from typing import Optional
+
+import aiohttp
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+from comet.core.config_validation import config_check
+from comet.utils.http_client import http_client_manager
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Internal HTTP helper
+# ---------------------------------------------------------------------------
+
+async def _fetch_json(url: str, timeout: int = 15) -> Optional[dict]:
+    try:
+        session = await http_client_manager.get_session()
+        async with session.get(
+            url,
+            timeout=__import__("aiohttp").ClientTimeout(total=timeout),
+            headers={"Accept": "application/json"},
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json(content_type=None)
+                logger.info(f"Custom catalog: fetch success for {url}")
+                return data
+            logger.warning(f"Custom catalog: HTTP {resp.status} for {url}")
+            try:
+                text = await resp.text()
+                logger.warning(f"Custom catalog err body: {text}")
+            except Exception:
+                pass
+    except asyncio.TimeoutError:
+        logger.warning(f"Custom catalog: timeout fetching {url}")
+    except Exception as e:
+        logger.warning(f"Custom catalog: error fetching {url}: {e}")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve custom-prefix ID → IMDB ID
+# ---------------------------------------------------------------------------
+
+async def resolve_custom_prefix_to_imdb(
+    media_type: str,
+    media_id: str,
+    custom_catalogs: list,
+    timeout: int = 15,
+) -> tuple[Optional[str], Optional[dict]]:
+    """
+    For a media_id whose prefix matches one of the user's customCatalogs,
+    call /meta/{type}/{media_id}.json on the corresponding addon URL and
+    attempt to extract an IMDB ID from the response.
+
+    Returns ``(imdb_id, meta_dict)``. If IMDB ID is not found, imdb_id is None,
+    but meta_dict might still contain title/year for fallback scraping.
+    """
+    matched_url: Optional[str] = None
+    for entry in custom_catalogs or []:
+        prefix = (entry.get("prefix") or "").strip()
+        url = (entry.get("url") or "").strip().rstrip("/")
+        if prefix and url and media_id.startswith(prefix):
+            matched_url = url
+            break
+
+    if not matched_url:
+        logger.warning(
+            f"Custom catalog plugin logic: NO MATCHED URL for {media_id}")
+        return None, None
+
+    # Stremio uses IDs like prefix123:1:2 for series streams, but custom catalogs
+    # usually only respond to the base ID (e.g. prefix123) for meta endpoints.
+    base_id = media_id.split(":")[0]
+
+    meta_url = f"{matched_url}/meta/{media_type}/{base_id}.json"
+    logger.info(f"Custom catalog: requesting IMDB resolution from {meta_url}")
+    data = await _fetch_json(meta_url, timeout)
+    if not data:
+        logger.warning(
+            f"Custom catalog: fetch returned empty/none for {meta_url}")
+        return None, None
+
+    meta = data.get("meta") or {}
+    logger.info(f"Custom catalog: received meta keys = {list(meta.keys())}")
+
+    # Try common locations for IMDB ID – adjust to actual API response structure
+    for candidate in [
+        meta.get("imdbId"),
+        meta.get("imdb"),
+        meta.get("tt"),
+        (meta.get("externalIds") or {}).get("imdb"),
+        (meta.get("externalIds") or {}).get("imdbId"),
+        (meta.get("filmOverviewOut") or {}).get("imdbId"),
+        ((meta.get("filmOverviewOut") or {}).get("externalIds") or {}).get("imdb"),
+    ]:
+        if candidate and str(candidate).startswith("tt"):
+            return str(candidate), meta
+
+    return None, meta
+
+
+# ---------------------------------------------------------------------------
+# Catalog proxy endpoints
+# ---------------------------------------------------------------------------
+
+def _parse_catalog_id(catalog_id: str) -> Optional[tuple]:
+    """
+    Parse a catalog ID of the form ``cstm{idx}_{prefix}_{type}``.
+    Returns ``(idx, prefix, catalog_type)`` or ``None``.
+    """
+    if not catalog_id.startswith("cstm"):
+        return None
+    rest = catalog_id[4:]  # strip "cstm"
+    try:
+        underscore_pos = rest.index("_")
+        idx = int(rest[:underscore_pos])
+        remainder = rest[underscore_pos + 1:]
+        # remainder is "{prefix}_{type}" – split at the *last* underscore
+        # because prefix itself may not contain underscores and type is
+        # always the rightmost segment.
+        last_underscore = remainder.rfind("_")
+        if last_underscore < 0:
+            return None
+        prefix = remainder[:last_underscore]
+        cat_type = remainder[last_underscore + 1:]
+        if not prefix or not cat_type:
+            return None
+        return idx, prefix, cat_type
+    except (ValueError, IndexError):
+        return None
+
+
+async def _handle_catalog(
+    b64config: str,
+    catalog_type: str,
+    catalog_id: str,
+    extra: str,
+) -> JSONResponse:
+    parsed = _parse_catalog_id(catalog_id)
+    if not parsed:
+        return JSONResponse({"metas": []})
+
+    idx, prefix, _declared_type = parsed
+
+    config = config_check(b64config, strict_b64config=False)
+    if not config:
+        return JSONResponse({"metas": []})
+
+    custom_catalogs = config.get("customCatalogs") or []
+    if idx >= len(custom_catalogs):
+        logger.warning(
+            f"Custom catalog: index {idx} out of range for user config")
+        return JSONResponse({"metas": []})
+
+    entry = custom_catalogs[idx]
+    base_url = (entry.get("url") or "").strip().rstrip("/")
+    entry_prefix = (entry.get("prefix") or "").strip()
+
+    if not base_url or not entry_prefix:
+        return JSONResponse({"metas": []})
+
+    # Safety: verify prefix still matches what is stored in user config
+    if entry_prefix != prefix:
+        logger.warning(
+            f"Custom catalog: prefix mismatch: config has {entry_prefix!r}, "
+            f"catalog_id implies {prefix!r}"
+        )
+        return JSONResponse({"metas": []})
+
+    # The original catalog ID on the remote addon is constructed from the prefix
+    # and the requested catalog type.  The manifest endpoint registers catalogs
+    # using the pattern ``cstm{idx}_{prefix}_{type}`` which maps to
+    # ``{prefix}_{catalog_type}`` on the upstream addon.
+    original_catalog_id = f"{prefix}_{catalog_type}"
+    if extra:
+        proxy_url = f"{base_url}/catalog/{catalog_type}/{original_catalog_id}/{extra}.json"
+    else:
+        proxy_url = f"{base_url}/catalog/{catalog_type}/{original_catalog_id}.json"
+
+    data = await _fetch_json(proxy_url)
+    if data and isinstance(data.get("metas"), list):
+        return JSONResponse(
+            content=data,
+            headers={"Access-Control-Allow-Origin": "*"},
+        )
+    return JSONResponse(
+        content={"metas": []},
+        headers={"Access-Control-Allow-Origin": "*"},
+    )
+
+
+@router.get(
+    "/{b64config}/catalog/{catalog_type}/{catalog_id}.json",
+    tags=["Stremio"],
+    summary="Custom Catalog Proxy",
+    description="Proxies catalog requests to user-configured external Stremio catalog addons.",
+)
+async def catalog(b64config: str, catalog_type: str, catalog_id: str):
+    return await _handle_catalog(b64config, catalog_type, catalog_id, extra="")
+
+
+@router.get(
+    "/{b64config}/catalog/{catalog_type}/{catalog_id}/{extra:path}.json",
+    tags=["Stremio"],
+    summary="Custom Catalog Proxy (with extra)",
+    description="Proxies catalog requests with extra params (search, skip, genre…) to external catalog addons.",
+)
+async def catalog_with_extra(b64config: str, catalog_type: str, catalog_id: str, extra: str):
+    return await _handle_catalog(b64config, catalog_type, catalog_id, extra=extra)

--- a/comet/api/endpoints/manifest.py
+++ b/comet/api/endpoints/manifest.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Request
 
 from comet.core.config_validation import config_check
-from comet.core.models import settings
+from comet.core.models import BUILTIN_PREFIXES, settings
 from comet.debrid.manager import build_addon_name
 from comet.utils.cache import (CachedJSONResponse, CachePolicies,
                                check_etag_match, generate_etag,
@@ -9,17 +9,14 @@ from comet.utils.cache import (CachedJSONResponse, CachePolicies,
 
 router = APIRouter()
 
-# ID prefixes that are always handled natively (not via custom catalogs)
-_BUILTIN_PREFIXES = {"tt", "kitsu"}
-
 
 def _build_custom_catalog_manifest(custom_catalogs: list) -> tuple[list, list]:
     """
     Given a user's customCatalogs config (list of {url, prefix} dicts),
     return (stremio_catalogs, extra_id_prefixes).
 
-    stremio_catalogs – catalog entries to include in the manifest
-    extra_id_prefixes – additional idPrefixes to advertise so Stremio sends
+    stremio_catalogs - catalog entries to include in the manifest
+    extra_id_prefixes - additional idPrefixes to advertise so Stremio sends
                         stream requests for IDs with those prefixes to Comet
     """
     stremio_catalogs = []
@@ -31,7 +28,7 @@ def _build_custom_catalog_manifest(custom_catalogs: list) -> tuple[list, list]:
         prefix = (entry.get("prefix") or "").strip()
         if not url or not prefix:
             continue
-        if prefix in _BUILTIN_PREFIXES:
+        if prefix in BUILTIN_PREFIXES:
             continue  # never override built-ins
 
         # One search-style catalog per custom addon (minimal; Stremio will

--- a/comet/api/endpoints/manifest.py
+++ b/comet/api/endpoints/manifest.py
@@ -9,6 +9,51 @@ from comet.utils.cache import (CachedJSONResponse, CachePolicies,
 
 router = APIRouter()
 
+# ID prefixes that are always handled natively (not via custom catalogs)
+_BUILTIN_PREFIXES = {"tt", "kitsu"}
+
+
+def _build_custom_catalog_manifest(custom_catalogs: list) -> tuple[list, list]:
+    """
+    Given a user's customCatalogs config (list of {url, prefix} dicts),
+    return (stremio_catalogs, extra_id_prefixes).
+
+    stremio_catalogs – catalog entries to include in the manifest
+    extra_id_prefixes – additional idPrefixes to advertise so Stremio sends
+                        stream requests for IDs with those prefixes to Comet
+    """
+    stremio_catalogs = []
+    extra_prefixes = []
+
+    seen_prefixes = set()
+    for idx, entry in enumerate(custom_catalogs or []):
+        url = (entry.get("url") or "").strip().rstrip("/")
+        prefix = (entry.get("prefix") or "").strip()
+        if not url or not prefix:
+            continue
+        if prefix in _BUILTIN_PREFIXES:
+            continue  # never override built-ins
+
+        # One search-style catalog per custom addon (minimal; Stremio will
+        # discover via the addon's own manifest, but we still expose it so
+        # the user can search from the Comet manifest).
+        stremio_catalogs.append({
+            "type": "movie",
+            "id": f"cstm{idx}_{prefix}_movie",
+            "name": f"Custom ({prefix})",
+        })
+        stremio_catalogs.append({
+            "type": "series",
+            "id": f"cstm{idx}_{prefix}_series",
+            "name": f"Custom ({prefix})",
+        })
+
+        if prefix not in seen_prefixes:
+            extra_prefixes.append(prefix)
+            seen_prefixes.add(prefix)
+
+    return stremio_catalogs, extra_prefixes
+
 
 @router.get(
     "/manifest.json",
@@ -50,6 +95,34 @@ async def manifest(request: Request, b64config: str = None):
         return base_manifest
 
     base_manifest["name"] = build_addon_name(settings.ADDON_NAME, config)
+
+    # Inject custom catalog entries and extra idPrefixes from user config
+    custom_catalogs_cfg = config.get("customCatalogs") or []
+    if custom_catalogs_cfg:
+        stremio_catalogs, extra_prefixes = _build_custom_catalog_manifest(
+            custom_catalogs_cfg)
+        if stremio_catalogs:
+            base_manifest["catalogs"] = stremio_catalogs
+            # Add "catalog" to resources if not already present
+            resource_names = [
+                r["name"] if isinstance(r, dict) else r
+                for r in base_manifest["resources"]
+            ]
+            if "catalog" not in resource_names:
+                base_manifest["resources"].append("catalog")
+
+        if extra_prefixes:
+            # Extend the stream resource's idPrefixes
+            stream_resource = next(
+                (r for r in base_manifest["resources"] if isinstance(
+                    r, dict) and r.get("name") == "stream"),
+                None,
+            )
+            if stream_resource:
+                existing = stream_resource.get("idPrefixes", [])
+                stream_resource["idPrefixes"] = existing + [
+                    p for p in extra_prefixes if p not in existing
+                ]
 
     if settings.HTTP_CACHE_ENABLED:
         etag = generate_etag(base_manifest)

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from urllib.parse import quote
 
 from fastapi import APIRouter, BackgroundTasks, Request
+from typing import Optional
 
 from comet.core.config_validation import config_check
 from comet.core.logger import logger
@@ -23,6 +24,7 @@ from comet.services.trackers import trackers
 from comet.utils.cache import (CachedJSONResponse, CachePolicies,
                                check_etag_match, generate_etag,
                                not_modified_response)
+from comet.api.endpoints.custom_catalog import resolve_custom_prefix_to_imdb
 from comet.utils.formatting import (format_chilllink, format_title,
                                     get_formatted_components,
                                     get_formatted_components_plain)
@@ -254,7 +256,8 @@ async def background_scrape(
             f"📥 Background scrape complete for {media_id}!",
         )
     except Exception as e:
-        logger.log("SCRAPER", f"❌ Background scrape failed for {media_id}: {e}")
+        logger.log(
+            "SCRAPER", f"❌ Background scrape failed for {media_id}: {e}")
     finally:
         await scrape_lock.release()
 
@@ -291,7 +294,8 @@ async def check_multi_service_availability(
 
         for result in results:
             if isinstance(result, Exception):
-                logger.log("DEBRID", f"❌ Error checking availability: {result}")
+                logger.log(
+                    "DEBRID", f"❌ Error checking availability: {result}")
                 continue
             service, cached_hashes = result
             for info_hash in cached_hashes:
@@ -421,7 +425,8 @@ async def stream(
     enable_torrent = config["_enableTorrent"]
     deduplicate_streams = config["deduplicateStreams"]
     scrape_debrid_account_torrents = config["scrapeDebridAccountTorrents"]
-    use_account_scrape = bool(debrid_entries and scrape_debrid_account_torrents)
+    use_account_scrape = bool(
+        debrid_entries and scrape_debrid_account_torrents)
     response_cache_policy = CachePolicies.no_cache() if use_account_scrape else None
 
     def _stream_response(content: dict, is_empty: bool = False):
@@ -447,6 +452,43 @@ async def stream(
     session = await http_client_manager.get_session()
     metadata_scraper = MetadataScraper(session)
 
+    # Resolve custom-prefix IDs (e.g. csfd12345 → tt0111161)
+    custom_catalogs = config.get("customCatalogs") or []
+    custom_meta_title: Optional[str] = None
+    custom_meta_year: Optional[int] = None
+
+    if custom_catalogs:
+        # Check if media_id starts with any user-configured custom prefix
+        for _entry in custom_catalogs:
+            _prefix = (_entry.get("prefix") or "").strip()
+            if _prefix and media_id.startswith(_prefix):
+                resolved_id, resolved_meta = await resolve_custom_prefix_to_imdb(
+                    media_type, media_id, custom_catalogs
+                )
+                if resolved_id:
+                    logger.log(
+                        "SCRAPER", f"Custom prefix: resolved {media_id} → {resolved_id}")
+                    media_id = resolved_id
+                elif resolved_meta and resolved_meta.get("name"):
+                    logger.log(
+                        "SCRAPER", f"Custom prefix: no IMDB ID for {media_id}, but found metadata.")
+                    custom_meta_title = resolved_meta.get("name")
+
+                    # Parse year from "2026-2026" or "2026" or "2026-"
+                    year_str = str(resolved_meta.get("year")
+                                   or resolved_meta.get("releaseInfo") or "")
+                    if year_str:
+                        # try to get the first 4 digits
+                        import re
+                        match = re.search(r'\d{4}', year_str)
+                        if match:
+                            custom_meta_year = int(match.group(0))
+                else:
+                    logger.warning(
+                        f"Custom prefix: could not resolve {media_id} to anything, returning empty streams")
+                    return _stream_response({"streams": []}, is_empty=True)
+                break
+
     id, season, episode = parse_media_id(media_type, media_id)
 
     if settings.DIGITAL_RELEASE_FILTER:
@@ -455,7 +497,8 @@ async def stream(
         )
 
         if not is_released:
-            logger.log("FILTER", f"🚫 {media_id} is not released yet. Skipping.")
+            logger.log(
+                "FILTER", f"🚫 {media_id} is not released yet. Skipping.")
             return _stream_response(
                 {
                     "streams": [
@@ -471,9 +514,17 @@ async def stream(
                 is_empty=True,
             )
 
-    metadata, aliases = await metadata_scraper.fetch_metadata_and_aliases(
-        media_type, media_id, id, season, episode
-    )
+    if custom_meta_title and custom_meta_year:
+        metadata, aliases = await metadata_scraper.fetch_aliases_with_metadata(
+            media_type, media_id, custom_meta_title, custom_meta_year, None, id
+        )
+        if metadata is not None:
+            metadata["season"] = season
+            metadata["episode"] = episode
+    else:
+        metadata, aliases = await metadata_scraper.fetch_metadata_and_aliases(
+            media_type, media_id, id, season, episode
+        )
 
     if metadata is None:
         logger.log("SCRAPER", f"❌ Failed to fetch metadata for {media_id}")
@@ -728,7 +779,8 @@ async def stream(
         existing_service_cache_status = await check_multi_service_availability(
             debrid_entries, torrent_manager.torrents, search_season, search_episode
         )
-        _merge_service_cache_status(service_cache_status, existing_service_cache_status)
+        _merge_service_cache_status(
+            service_cache_status, existing_service_cache_status)
         _merge_service_cache_status(
             verified_service_cache_status, existing_service_cache_status
         )
@@ -779,7 +831,8 @@ async def stream(
             search_episode,
             ip,
         )
-        _merge_service_cache_status(service_cache_status, fresh_service_cache_status)
+        _merge_service_cache_status(
+            service_cache_status, fresh_service_cache_status)
 
         for service, error in debrid_errors.items():
             cached_results.append(
@@ -906,7 +959,8 @@ async def stream(
             config["resultFormat"],
         )
         formatted_title = format_title_fn(formatted_components)
-        kodi_meta = _build_kodi_meta(rtn_data, formatted_components) if kodi else None
+        kodi_meta = _build_kodi_meta(
+            rtn_data, formatted_components) if kodi else None
         info_hash_cache_status = service_cache_status.get(info_hash)
         quoted_torrent_title = quote(torrent_title)
 
@@ -1005,7 +1059,8 @@ async def stream(
             }
 
             if chilllink:
-                the_stream["_chilllink"] = format_chilllink(formatted_components, False)
+                the_stream["_chilllink"] = format_chilllink(
+                    formatted_components, False)
 
             if torrent.get("fileIndex") is not None:
                 the_stream["fileIdx"] = torrent["fileIndex"]

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -2,6 +2,7 @@ import asyncio
 from collections import defaultdict
 from urllib.parse import quote
 
+import re
 from fastapi import APIRouter, BackgroundTasks, Request
 from typing import Optional
 
@@ -479,7 +480,6 @@ async def stream(
                                    or resolved_meta.get("releaseInfo") or "")
                     if year_str:
                         # try to get the first 4 digits
-                        import re
                         match = re.search(r'\d{4}', year_str)
                         if match:
                             custom_meta_year = int(match.group(0))

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -469,7 +469,10 @@ async def stream(
                 if resolved_id:
                     logger.log(
                         "SCRAPER", f"Custom prefix: resolved {media_id} → {resolved_id}")
-                    media_id = resolved_id
+                    # Preserve the :season:episode suffix (e.g. ":1:2") that Stremio
+                    # appends to IDs for series so parse_media_id() still gets it.
+                    suffix = media_id[len(media_id.split(":")[0]):]
+                    media_id = f"{resolved_id}{suffix}"
                 elif resolved_meta and resolved_meta.get("name"):
                     logger.log(
                         "SCRAPER", f"Custom prefix: no IMDB ID for {media_id}, but found metadata.")

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -1,3 +1,14 @@
+from comet.core.logger import logger
+from comet.core.db_router import ReplicaAwareDatabase
+from RTN.models import (AudioRankModel, CustomRank, CustomRanksConfig,
+                        ExtrasRankModel, HdrRankModel, LanguagesConfig,
+                        OptionsConfig, QualityRankModel, ResolutionConfig,
+                        RipsRankModel)
+from RTN import DefaultRanking, SettingsModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel, Field, field_validator
+from databases import Database
+import RTN
 import os
 import random
 import secrets
@@ -5,18 +16,7 @@ import string
 import time
 from typing import List, Optional, Union
 
-import RTN
-from databases import Database
-from pydantic import BaseModel, Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from RTN import DefaultRanking, SettingsModel
-from RTN.models import (AudioRankModel, CustomRank, CustomRanksConfig,
-                        ExtrasRankModel, HdrRankModel, LanguagesConfig,
-                        OptionsConfig, QualityRankModel, ResolutionConfig,
-                        RipsRankModel)
-
-from comet.core.db_router import ReplicaAwareDatabase
-from comet.core.logger import logger
+BUILTIN_PREFIXES = {"tt", "kitsu"}
 
 
 class AppSettings(BaseSettings):
@@ -1029,7 +1029,7 @@ class ConfigModel(BaseModel):
             url = str(entry.get("url") or "").strip().rstrip("/")
             prefix = str(entry.get("prefix") or "").strip()
             # Skip entries with missing data or that would override built-in prefixes
-            if url and prefix and prefix not in ("tt", "kitsu"):
+            if url and prefix and prefix not in BUILTIN_PREFIXES:
                 sanitized.append({"url": url, "prefix": prefix})
         return sanitized
 

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -92,9 +92,11 @@ class AppSettings(BaseSettings):
     SCRAPE_NEKOBT: Union[bool, str] = False
     NEKOBT_ANIME_ONLY: Optional[bool] = True
     SCRAPE_ZILEAN: Union[bool, str] = False
-    ZILEAN_URL: Union[str, List[str]] = "https://zileanfortheweebs.midnightignite.me"
+    ZILEAN_URL: Union[str, List[str]
+                      ] = "https://zileanfortheweebs.midnightignite.me"
     SCRAPE_STREMTHRU: Union[bool, str] = False
-    STREMTHRU_SCRAPE_URL: Union[str, List[str]] = "https://stremthru.13377001.xyz"
+    STREMTHRU_SCRAPE_URL: Union[str, List[str]
+                                ] = "https://stremthru.13377001.xyz"
     SCRAPE_DMM: Union[bool, str] = False
     DMM_INGEST_ENABLED: Optional[bool] = False
     DMM_INGEST_INTERVAL: Optional[int] = 86400
@@ -109,7 +111,8 @@ class AppSettings(BaseSettings):
     SCRAPE_TORRENTIO: Union[bool, str] = False
     TORRENTIO_URL: Union[str, List[str]] = "https://torrentio.strem.fun"
     SCRAPE_MEDIAFUSION: Union[bool, str] = False
-    MEDIAFUSION_URL: Union[str, List[str]] = "https://mediafusion.elfhosted.com"
+    MEDIAFUSION_URL: Union[str, List[str]
+                           ] = "https://mediafusion.elfhosted.com"
     MEDIAFUSION_API_PASSWORD: Union[str, List[str], None] = None
     MEDIAFUSION_LIVE_SEARCH: Optional[bool] = True
     SCRAPE_AIOSTREAMS: Union[bool, str] = False
@@ -251,14 +254,16 @@ class AppSettings(BaseSettings):
         10000.0  # Max acceptable latency before disconnection
     )
     COMETNET_TRANSPORT_RATE_LIMIT_ENABLED: Optional[bool] = True
-    COMETNET_TRANSPORT_RATE_LIMIT_COUNT: Optional[int] = 20  # Messages per window
+    # Messages per window
+    COMETNET_TRANSPORT_RATE_LIMIT_COUNT: Optional[int] = 20
     COMETNET_TRANSPORT_RATE_LIMIT_WINDOW: Optional[float] = 1.0  # Seconds
 
     # CometNet Reputation Tuning
     COMETNET_REPUTATION_INITIAL: Optional[float] = 100.0
     COMETNET_REPUTATION_MIN: Optional[float] = 0.0
     COMETNET_REPUTATION_MAX: Optional[float] = 10000.0
-    COMETNET_REPUTATION_THRESHOLD_UNTRUSTED: Optional[float] = 50.0  # Ban threshold
+    # Ban threshold
+    COMETNET_REPUTATION_THRESHOLD_UNTRUSTED: Optional[float] = 50.0
     COMETNET_REPUTATION_THRESHOLD_TRUSTED: Optional[float] = (
         1000.0  # Trust threshold (approx 1 day of heavy scraping)
     )
@@ -450,7 +455,8 @@ def _resolve_persisted_token(
         except FileNotFoundError:
             pass
         except Exception as error:
-            logger.warning(f"Failed to read {token_name}_FILE ({token_file}): {error}")
+            logger.warning(
+                f"Failed to read {token_name}_FILE ({token_file}): {error}")
 
     generated_token = secrets.token_urlsafe(32)
     if not token_file:
@@ -483,7 +489,8 @@ def _resolve_persisted_token(
             ) from last_read_error
         raise RuntimeError(error_context) from None
     except Exception as error:
-        logger.error(f"Failed to persist {token_name}_FILE ({token_file}): {error}")
+        logger.error(
+            f"Failed to persist {token_name}_FILE ({token_file}): {error}")
         raise
 
 
@@ -1002,6 +1009,30 @@ class ConfigModel(BaseModel):
     rtnSettings: Optional[CometSettingsModel] = rtn_settings_default
     rtnRanking: Optional[DefaultRanking] = rtn_ranking_default
 
+    # Custom catalog addons configured per-user via the configure page
+    # Each entry: {"url": "https://...", "prefix": "csfd"}
+    # The prefix is used to route stream requests to the correct catalog addon.
+    # The "tt" prefix is always handled by Cinemeta (built-in).
+    customCatalogs: Optional[List[dict]] = []
+
+    @field_validator("customCatalogs", mode="before")
+    @classmethod
+    def validate_custom_catalogs(cls, v):
+        if not v:
+            return []
+        if not isinstance(v, list):
+            return []
+        sanitized = []
+        for entry in v:
+            if not isinstance(entry, dict):
+                continue
+            url = str(entry.get("url") or "").strip().rstrip("/")
+            prefix = str(entry.get("prefix") or "").strip()
+            # Skip entries with missing data or that would override built-in prefixes
+            if url and prefix and prefix not in ("tt", "kitsu"):
+                sanitized.append({"url": url, "prefix": prefix})
+        return sanitized
+
     @field_validator("maxResultsPerResolution")
     def check_max_results_per_resolution(cls, v):
         if not isinstance(v, int):
@@ -1032,7 +1063,8 @@ class ConfigModel(BaseModel):
             return []
         if isinstance(v, list):
             return [
-                DebridServiceEntry(**entry) if isinstance(entry, dict) else entry
+                DebridServiceEntry(
+                    **entry) if isinstance(entry, dict) else entry
                 for entry in v
             ]
         return v
@@ -1065,7 +1097,7 @@ def _build_database_instance(raw_url: str):
 
     for scheme in ["postgresql://", "postgres://"]:
         if raw_url.startswith(scheme):
-            raw_url = raw_url[len(scheme) :]
+            raw_url = raw_url[len(scheme):]
             break
 
     return Database(f"postgresql+asyncpg://{raw_url}")

--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -518,6 +518,35 @@
       </sl-details>
 
       <style>
+        .custom-catalog-entry {
+          display: grid;
+          grid-template-columns: 2fr 1fr auto;
+          gap: 0.75rem;
+          align-items: center;
+          padding: 0.75rem;
+          background: rgba(255, 255, 255, 0.03);
+          border-radius: 0.5rem;
+          margin-bottom: 0.5rem;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          transition: border-color 0.2s ease;
+        }
+
+        .custom-catalog-entry:hover {
+          border-color: rgba(255, 255, 255, 0.2);
+        }
+
+        .custom-catalog-entry .remove-btn {
+          color: var(--sl-color-danger-600);
+        }
+
+        @media (max-width: 600px) {
+          .custom-catalog-entry {
+            grid-template-columns: 1fr;
+          }
+        }
+      </style>
+
+      <style>
         .debrid-service-entry {
           display: grid;
           grid-template-columns: 1fr 2fr auto;
@@ -884,6 +913,94 @@
         </div>
       </sl-details>
 
+      <sl-details summary="Custom Catalogs">
+        <p style="margin: 0 0 0.75rem; color: var(--sl-color-neutral-500); font-size: 0.875rem; line-height: 1.5;">
+          Add external Stremio-compatible catalog addons. Each entry has a <strong>URL</strong> (the addon base URL) and a <strong>prefix</strong>
+          used to route requests – e.g. <code>csfd</code> for Kinobox. The <code>tt</code> prefix is always handled by Cinemeta.
+        </p>
+
+        <div id="customCatalogsContainer"></div>
+
+        <sl-button
+          id="addCustomCatalog"
+          variant="default"
+          size="small"
+          style="margin-bottom: 1rem"
+        >
+          <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+          Add Custom Catalog
+        </sl-button>
+
+        <script>
+          let customCatalogCounter = 0;
+
+          function createCustomCatalogEntry(url = "", prefix = "") {
+            const container = document.getElementById("customCatalogsContainer");
+            const entryId = customCatalogCounter++;
+
+            const entry = document.createElement("div");
+            entry.className = "custom-catalog-entry";
+            entry.dataset.entryId = entryId;
+
+            entry.innerHTML = `
+              <sl-input
+                class="catalog-url-input"
+                value="${url.replace(/"/g, '&quot;')}"
+                placeholder="https://your-addon.example.com"
+                size="small"
+                label="Catalog URL"
+                clearable
+              ></sl-input>
+              <sl-input
+                class="catalog-prefix-input"
+                value="${prefix.replace(/"/g, '&quot;')}"
+                placeholder="csfd"
+                size="small"
+                label="ID Prefix"
+                clearable
+              ></sl-input>
+              <sl-icon-button class="remove-btn" name="trash" label="Remove" style="margin-top: 1.2rem;"></sl-icon-button>
+            `;
+
+            const removeBtn = entry.querySelector(".remove-btn");
+            removeBtn.addEventListener("click", () => entry.remove());
+
+            container.appendChild(entry);
+            return entry;
+          }
+
+          function getCustomCatalogs() {
+            const container = document.getElementById("customCatalogsContainer");
+            const entries = container.querySelectorAll(".custom-catalog-entry");
+            const catalogs = [];
+
+            entries.forEach(entry => {
+              const url = entry.querySelector(".catalog-url-input").value.trim();
+              const prefix = entry.querySelector(".catalog-prefix-input").value.trim();
+              if (url && prefix) {
+                catalogs.push({ url, prefix });
+              }
+            });
+
+            return catalogs;
+          }
+
+          function populateCustomCatalogs(catalogs) {
+            const container = document.getElementById("customCatalogsContainer");
+            container.innerHTML = "";
+            customCatalogCounter = 0;
+            if (catalogs && catalogs.length > 0) {
+              catalogs.forEach(entry => createCustomCatalogEntry(entry.url || "", entry.prefix || ""));
+            }
+          }
+
+          document.addEventListener("DOMContentLoaded", () => {
+            const addBtn = document.getElementById("addCustomCatalog");
+            addBtn.addEventListener("click", () => createCustomCatalogEntry());
+          });
+        </script>
+      </sl-details>
+
       <sl-details summary="Advanced Settings">
         <div class="form-item">
           <sl-input
@@ -1144,6 +1261,8 @@
             const resultFormat = Array.from(document.getElementById("resultFormat").selectedOptions).map(option => option.value);
             const debridStreamProxyPassword = document.getElementById("debridStreamProxyPassword").value;
 
+            const customCatalogs = getCustomCatalogs();
+
             const debridServices = getDebridServices();
             const enableTorrentEl = document.getElementById("enableTorrent");
             const enableTorrent = enableTorrentEl ? enableTorrentEl.checked : false;
@@ -1166,6 +1285,7 @@
               deduplicateStreams: deduplicateStreams,
               scrapeDebridAccountTorrents: scrapeDebridAccountTorrents,
               debridStreamProxyPassword: debridStreamProxyPassword,
+              customCatalogs: customCatalogs,
               languages: {
                 required: languages_required,
                 allowed: languages_allowed,
@@ -1186,6 +1306,11 @@
           function isDefaultConfig(settings) {
             // For default: no debrid services and torrent mode enabled
             if (settings.debridServices && settings.debridServices.length > 0) {
+              return false;
+            }
+
+            // Non-empty customCatalogs makes config non-default
+            if (settings.customCatalogs && settings.customCatalogs.length > 0) {
               return false;
             }
 
@@ -1509,6 +1634,8 @@
               document.getElementById("allowEnglishInLanguages").checked = settings.options.allow_english_in_languages;
             if (settings.options?.remove_unknown_languages !== undefined)
               document.getElementById("removeUnknownLanguages").checked = settings.options.remove_unknown_languages;
+            if (settings.customCatalogs && settings.customCatalogs.length > 0)
+              populateCustomCatalogs(settings.customCatalogs);
           }
         </script>
       </div>


### PR DESCRIPTION
## Summary

Adds the ability for each Comet user to configure one or more external Stremio-compatible catalog addons directly on the `/configure` page. Custom catalog prefixes (e.g. `csfd`) are routed to the user-specified addon URL, while the `tt` prefix continues to be handled by Cinemeta as normal.

## Motivation

Comet users running adjacent addons (e.g. Kinobox) want to browse those catalogs and play streams through Comet's debrid infrastructure. Previously this required server-side env var configuration and a restart. This PR makes it a zero-config per-user setting stored in the base64 config URL.

## Changes

### `comet/templates/index.html` — Configure page UI

A new **"Custom Catalogs"** collapsible section is added to the configure page. Users can:

- Add any number of catalog entries with **Catalog URL** + **ID Prefix** fields
- Remove entries with a trash icon
- Entries are saved into the b64 config and restored when re-opening configure

The `customCatalogs` array (`[{url, prefix}, ...]`) is included in all generated manifest URLs and is restored when the user reconfigures.

---

### `comet/core/models.py` — `ConfigModel`

```python
customCatalogs: Optional[List[dict]] = []
```

- New field on `ConfigModel` so the per-user b64 config preserves custom catalog entries (previously they were silently dropped during validation)
- Pydantic `field_validator` sanitizes each entry: strips whitespace, removes entries with empty URL or prefix, and **blocks overriding built-in prefixes** `tt` and `kitsu`

---

### `comet/api/endpoints/manifest.py` — Manifest endpoint

When the user has `customCatalogs` configured:

- Adds **catalog entries** to the manifest (`cstm{idx}_{prefix}_movie`, `cstm{idx}_{prefix}_series`) so Stremio shows the catalogs
- Adds custom **`idPrefixes`** to the stream resource so Stremio sends stream requests for those IDs to Comet (e.g. Stremio will call `/stream/movie/csdf12345.json` on Comet instead of ignoring it)
- No changes to manifest output when `customCatalogs` is empty — **fully backward-compatible**

---

### `comet/api/endpoints/custom_catalog.py` — New file

New FastAPI router with:

| Endpoint                                                 | Purpose                                        |
| -------------------------------------------------------- | ---------------------------------------------- |
| `GET /{b64config}/catalog/{type}/{id}.json`              | Proxy catalog page requests to user addon      |
| `GET /{b64config}/catalog/{type}/{id}/{extra:path}.json` | Proxy with extra params (search, skip, genre…) |

Catalog ID format: `cstm{idx}_{prefix}_{type}` → mapped back to `{prefix}_{type}` on the upstream addon.

Also exports `resolve_custom_prefix_to_imdb(media_type, media_id, custom_catalogs)` — calls `/meta/{type}/{base_id}.json` on the addon and tries several common response paths to extract the IMDB `tt...` ID. **Note:** Suffixes like `:1:2` (used for episodes) are automatically stripped before calling the custom catalog's `/meta` endpoint to prevent 404s.

Uses the shared `http_client_manager` (consistent with rest of codebase).

---

### `comet/api/endpoints/stream.py` — Stream endpoint

Before calling `parse_media_id`, the stream handler now checks if `media_id` starts with any of the user's custom prefixes. If so:

1. Calls `resolve_custom_prefix_to_imdb` to get the IMDB ID
2. If resolved → replaces `media_id` with `tt...` and continues the normal stream flow
3. If not resolved → returns empty stream list (graceful failure, no crash)

The `tt` prefix path is completely unchanged.

---

### `comet/api/app.py`

Imports `custom_catalog` and registers its router in `stremio_routers`.

---

## Backward Compatibility

| Scenario                                 | Behavior                                                           |
| ---------------------------------------- | ------------------------------------------------------------------ |
| No `customCatalogs` in user config       | Manifest unchanged, stream unchanged, no extra routes triggered    |
| Old b64 configs without `customCatalogs` | Field defaults to `[]`, no effect                                  |
| `tt` / `kitsu` prefix in custom catalog  | Validator silently drops the entry                                 |
| Addon URL / Meta unreachable             | Returns `{"metas": []}` / empty streams (logged warning, no crash) |

## Notes

### IMDB ID parsing

`resolve_custom_prefix_to_imdb` attempts these paths in the addon's `/meta` response:

```
meta.imdbId  ·  meta.imdb  ·  meta.tt
meta.externalIds.imdb  ·  meta.externalIds.imdbId
meta.filmOverviewOut.imdbId
meta.filmOverviewOut.externalIds.imdb
```

> **If your addon stores the IMDB ID elsewhere**, update the candidate list in `resolve_custom_prefix_to_imdb` in `custom_catalog.py`.

### Catalog ID proxy convention

The proxy constructs the upstream catalog ID as `{prefix}_{catalog_type}` (e.g. `csfd_movie`). If your addon uses a different catalog ID scheme, the proxy URL will need adjustment.

## Files Changed

| File                                    | Type     |
| --------------------------------------- | -------- |
| `comet/templates/index.html`            | Modified |
| `comet/core/models.py`                  | Modified |
| `comet/api/endpoints/manifest.py`       | Modified |
| `comet/api/endpoints/custom_catalog.py` | **New**  |
| `comet/api/endpoints/stream.py`         | Modified |
| `comet/api/app.py`                      | Modified |
… add new documentation files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom Catalogs UI in Settings to add/configure/remove external catalogs (URL + ID prefix).
  * Public proxy endpoints to expose configured catalogs in app catalogs and generated manifest.

* **Improvements**
  * Manifest now injects generated catalog entries and extra ID prefixes for custom catalogs.
  * Stream/metadata flow can resolve custom-prefix IDs to standard IDs and surface custom metadata.
  * Catalog proxy responses include permissive CORS.

* **Bug Fixes**
  * Validation, safety checks (SSRF protections), index/config bounds checks, and safe fallbacks with improved logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->