### PR TITLE
fix: don't use DOMContentLoaded as it isn't needed

### DIFF
--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -817,11 +817,9 @@
         }
 
         // Initialize add button
-        document.addEventListener("DOMContentLoaded", () => {
-          const addBtn = document.getElementById("addDebridService");
-          addBtn.addEventListener("click", () => {
-            createDebridServiceEntry();
-          });
+        const addBtn = document.getElementById("addDebridService");
+        addBtn.addEventListener("click", () => {
+          createDebridServiceEntry();
         });
       </script>
 
@@ -1001,7 +999,7 @@
           let defaultResultFormat = [];
           const ALL_RESOLUTIONS = ["r2160p", "r1440p", "r1080p", "r720p", "r576p", "r480p", "r360p", "r240p", "unknown"];
 
-          document.addEventListener("DOMContentLoaded", async () => {
+          (async () => {
             await Promise.allSettled([
               customElements.whenDefined("sl-button"),
               customElements.whenDefined("sl-alert"),
@@ -1038,7 +1036,7 @@
           populateSelect("languages_preferred", Object.keys(languagesEmojis));
 
           document.body.classList.add("ready");
-                });
+          })();
 
           function populateSelect(selectId, options) {
             const selectElement = document.getElementById(selectId);


### PR DESCRIPTION
Currently loading languages and result format is being done in `DOMContentLoaded ` which isn't needed
This causes issues with cloudflares rocketloader, and can be safely removed

This would also break loading existing configs

Example of the issue:
<img width="679" height="593" alt="image" src="https://github.com/user-attachments/assets/48cb1d40-35b2-4046-a2fc-7913e0b1acc6" />
<img width="634" height="546" alt="image" src="https://github.com/user-attachments/assets/61f8f933-b2fb-4e37-939d-43b175fb0491" />
