### PR TITLE
fix: prevent auto-scrolling when new logs are appended if not at the bottom

### DIFF
--- a/comet/templates/admin_dashboard.html
+++ b/comet/templates/admin_dashboard.html
@@ -2546,6 +2546,7 @@
 
       function appendLogs(logs) {
         const container = document.getElementById("logs-container");
+        const isAtBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 50;
         const hideApiLogs = document.getElementById("hide-api-logs").checked;
 
         if (container.querySelector(".empty-state")) {
@@ -2577,7 +2578,9 @@
           container.appendChild(logEntry);
         });
 
-        container.scrollTop = container.scrollHeight;
+        if (isAtBottom) {
+          container.scrollTop = container.scrollHeight;
+        }
 
         const maxEntries = 500;
         while (container.children.length > maxEntries) {


### PR DESCRIPTION
If you have a lot of new logs coming in constantly the logs will automatically scroll down each time which is annoying if you're trying to see something specific, this makes it so it only auto scrolls when you're near the bottom anyways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log scrolling behavior in the admin dashboard. The log container now intelligently auto-scrolls to the bottom only when you're already at the bottom, while preserving your scroll position when reviewing older logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->