### PR TITLE
fix(zilean): percent-encode DMM query titles

### DIFF
--- a/comet/scrapers/zilean.py
+++ b/comet/scrapers/zilean.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from comet.core.logger import logger
 from comet.scrapers.base import BaseScraper
 from comet.scrapers.models import ScrapeRequest
@@ -16,7 +18,7 @@ class ZileanScraper(BaseScraper):
                 else ""
             )
             data = await self.session.get(
-                f"{self.url}/dmm/filtered?query={request.title}{show}"
+                f"{self.url}/dmm/filtered?query={quote(request.title, safe='')}{show}"
             )
             data = await data.json()
 


### PR DESCRIPTION
## Summary
- percent-encode the Zilean `query` parameter so titles with spaces, parentheses, `&`, `+`, and non-ASCII characters are sent safely
- keep the change surgical by only wrapping `request.title` with `urllib.parse.quote(..., safe='')`
- preserve the existing season / episode query parameters by leaving the `show` suffix untouched

## Why
- `comet/scrapers/zilean.py` currently interpolates `request.title` directly into the URL query string
- raw interpolation can produce malformed or truncated lookups when titles contain URL-sensitive characters
- percent-encoding the title makes `/dmm/filtered?query=...` requests deterministic without changing behavior for simple titles

## Notes
- this change is intentionally scoped to `zilean.py`
- a similar raw query-string interpolation pattern exists in `comet/scrapers/prowlarr.py`; that can be handled separately
