### PR TITLE
fix(cometnet): batch sign torrents in batch broadcast endpoint

### DIFF
--- a/comet/cometnet/standalone.py
+++ b/comet/cometnet/standalone.py
@@ -430,21 +430,24 @@ class StandaloneCometNet:
                     status_code=503, detail="CometNet service not running"
                 )
 
-            queued = 0
             errors = []
+            metadata_batch = []
 
             for torrent in request.torrents:
                 try:
                     _require_broadcast_media_id(torrent.imdb_id)
                     metadata = TorrentMetadata(**torrent.model_dump())
-
-                    await self.service.broadcast_torrent(metadata)
-                    queued += 1
-                    self._broadcasts_success += 1
+                    metadata_batch.append(metadata)
                 except HTTPException as e:
                     errors.append({"info_hash": torrent.info_hash, "error": e.detail})
                 except Exception as e:
                     errors.append({"info_hash": torrent.info_hash, "error": str(e)})
+
+            if metadata_batch:
+                await self.service.broadcast_torrents(metadata_batch)
+
+            queued = len(metadata_batch)
+            self._broadcasts_success += queued
 
             if queued > 0:
                 logger.log(


### PR DESCRIPTION
The `/broadcast/batch` endpoint was calling `broadcast_torrent` (singular) in a loop, causing one executor signing call per torrent instead of one for the whole batch. This seems to be unintentional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Torrent metadata is now batched and submitted collectively rather than individually during broadcast operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->