### PR TITLE
perf(cometnet): disable permessage-deflate on WebSocket connections

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -451,6 +451,7 @@ COMETNET_TRANSPORT_MAX_CONNECTIONS_PER_IP=3 # Max connections allowed from a sin
 COMETNET_TRANSPORT_PING_INTERVAL=30.0 # Seconds between keepalive pings
 COMETNET_TRANSPORT_CONNECTION_TIMEOUT=120.0 # Seconds before dropping a silent connection
 COMETNET_TRANSPORT_MAX_LATENCY_MS=10000.0 # Max acceptable peer latency in ms (peers exceeding this are disconnected)
+COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED=False # Enable permessage-deflate. Saves bandwidth but adds synchronous CPU work on the event loop.
 COMETNET_TRANSPORT_RATE_LIMIT_ENABLED=True # Enable rate limiting for incoming messages
 COMETNET_TRANSPORT_RATE_LIMIT_COUNT=20 # Max messages per peer per window
 COMETNET_TRANSPORT_RATE_LIMIT_WINDOW=1.0 # Window size in seconds

--- a/comet/cometnet/manager.py
+++ b/comet/cometnet/manager.py
@@ -205,6 +205,7 @@ class CometNetService(CometNetBackend):
             f" - Ping={settings.COMETNET_TRANSPORT_PING_INTERVAL}s"
             f" - Timeout={settings.COMETNET_TRANSPORT_CONNECTION_TIMEOUT}s"
             f" - Max Latency={settings.COMETNET_TRANSPORT_MAX_LATENCY_MS}ms"
+            f" - WebSocket Compression={settings.COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED}"
             f" - RateLimit: {settings.COMETNET_TRANSPORT_RATE_LIMIT_ENABLED} "
             f"({settings.COMETNET_TRANSPORT_RATE_LIMIT_COUNT}/{settings.COMETNET_TRANSPORT_RATE_LIMIT_WINDOW}s)",
         )

--- a/comet/cometnet/standalone.py
+++ b/comet/cometnet/standalone.py
@@ -14,6 +14,7 @@ Environment Variables:
     COMETNET_KEYS_DIR: Directory for node identity keys
     COMETNET_BOOTSTRAP_NODES: List of bootstrap nodes (JSON array)
     COMETNET_MANUAL_PEERS: List of peers to connect to (JSON array)
+    COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED: Enable permessage-deflate (default: False)
     COMETNET_API_KEY: Mandatory API key for authenticating HTTP requests
 
 Security Notes:

--- a/comet/cometnet/transport.py
+++ b/comet/cometnet/transport.py
@@ -363,6 +363,7 @@ class ConnectionManager:
                 ping_timeout=None,
                 max_size=self.max_message_size,
                 process_request=self._process_request,
+                compression=None,
             )
             logger.log(
                 "COMETNET",
@@ -473,6 +474,7 @@ class ConnectionManager:
                     ping_interval=None,
                     ping_timeout=None,
                     max_size=self.max_message_size,
+                    compression=None,
                 ),
                 timeout=5.0,
             )

--- a/comet/cometnet/transport.py
+++ b/comet/cometnet/transport.py
@@ -201,6 +201,11 @@ class ConnectionManager:
         # Security limits from settings
         self.max_message_size = settings.COMETNET_TRANSPORT_MAX_MESSAGE_SIZE
         self.max_connections_per_ip = settings.COMETNET_TRANSPORT_MAX_CONNECTIONS_PER_IP
+        self.websocket_compression = (
+            "deflate"
+            if settings.COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED
+            else None
+        )
 
         # Rate limits
         self.rate_limit_count = settings.COMETNET_TRANSPORT_RATE_LIMIT_COUNT
@@ -363,7 +368,7 @@ class ConnectionManager:
                 ping_timeout=None,
                 max_size=self.max_message_size,
                 process_request=self._process_request,
-                compression=None,
+                compression=self.websocket_compression,
             )
             logger.log(
                 "COMETNET",
@@ -474,7 +479,7 @@ class ConnectionManager:
                     ping_interval=None,
                     ping_timeout=None,
                     max_size=self.max_message_size,
-                    compression=None,
+                    compression=self.websocket_compression,
                 ),
                 timeout=5.0,
             )

--- a/comet/cometnet/transport.py
+++ b/comet/cometnet/transport.py
@@ -26,7 +26,9 @@ from websockets.http11 import Response
 from comet.cometnet.crypto import NodeIdentity
 from comet.cometnet.protocol import (AnyMessage, HandshakeMessage, MessageType,
                                      PingMessage, PongMessage, parse_message)
-from comet.cometnet.utils import extract_ip_from_address, is_valid_peer_address
+from comet.cometnet.utils import (extract_ip_from_address,
+                                  get_websocket_compression,
+                                  is_valid_peer_address)
 from comet.core.logger import logger
 from comet.core.models import settings
 from comet.utils.network import extract_ip_from_headers
@@ -201,11 +203,7 @@ class ConnectionManager:
         # Security limits from settings
         self.max_message_size = settings.COMETNET_TRANSPORT_MAX_MESSAGE_SIZE
         self.max_connections_per_ip = settings.COMETNET_TRANSPORT_MAX_CONNECTIONS_PER_IP
-        self.websocket_compression = (
-            "deflate"
-            if settings.COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED
-            else None
-        )
+        self.websocket_compression = get_websocket_compression()
 
         # Rate limits
         self.rate_limit_count = settings.COMETNET_TRANSPORT_RATE_LIMIT_COUNT

--- a/comet/cometnet/utils.py
+++ b/comet/cometnet/utils.py
@@ -275,6 +275,11 @@ async def check_advertise_url_reachability(
                 advertise_url,
                 close_timeout=2,
                 open_timeout=timeout,
+                compression=(
+                    "deflate"
+                    if settings.COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED
+                    else None
+                ),
             ) as ws:
                 await ws.close()
                 return True, "WebSocket connection successful"

--- a/comet/cometnet/utils.py
+++ b/comet/cometnet/utils.py
@@ -27,6 +27,15 @@ T = TypeVar("T")
 _crypto_executor: Optional[ThreadPoolExecutor] = None
 
 
+def get_websocket_compression() -> Optional[str]:
+    """Return the websockets compression mode configured for CometNet."""
+    return (
+        "deflate"
+        if settings.COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED
+        else None
+    )
+
+
 def _get_crypto_executor() -> ThreadPoolExecutor:
     """Get or create the dedicated crypto thread pool."""
     global _crypto_executor
@@ -275,11 +284,7 @@ async def check_advertise_url_reachability(
                 advertise_url,
                 close_timeout=2,
                 open_timeout=timeout,
-                compression=(
-                    "deflate"
-                    if settings.COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED
-                    else None
-                ),
+                compression=get_websocket_compression(),
             ) as ws:
                 await ws.close()
                 return True, "WebSocket connection successful"

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -285,6 +285,7 @@ class AppSettings(BaseSettings):
     COMETNET_TRANSPORT_MAX_LATENCY_MS: Optional[float] = (
         10000.0  # Max acceptable latency before disconnection
     )
+    COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED: Optional[bool] = False
     COMETNET_TRANSPORT_RATE_LIMIT_ENABLED: Optional[bool] = True
     COMETNET_TRANSPORT_RATE_LIMIT_COUNT: Optional[int] = 20  # Messages per window
     COMETNET_TRANSPORT_RATE_LIMIT_WINDOW: Optional[float] = 1.0  # Seconds

--- a/docs/cometnet/cometnet.md
+++ b/docs/cometnet/cometnet.md
@@ -262,6 +262,7 @@ Private networks are completely separate from the public CometNet network. All n
 | `COMETNET_TRANSPORT_PING_INTERVAL` | `30.0` | Seconds between keepalive pings. |
 | `COMETNET_TRANSPORT_CONNECTION_TIMEOUT` | `120.0` | Seconds before dropping a silent connection. |
 | `COMETNET_TRANSPORT_MAX_LATENCY_MS` | `10000.0` | Maximum acceptable peer latency (ms). Peers exceeding this are disconnected. |
+| `COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED` | `False` | Enable WebSocket `permessage-deflate`. Saves bandwidth on large gossip messages but adds synchronous CPU work on the asyncio event loop. |
 | `COMETNET_TRANSPORT_RATE_LIMIT_ENABLED` | `True` | Enable rate limiting for incoming messages. |
 | `COMETNET_TRANSPORT_RATE_LIMIT_COUNT` | `20` | Max messages per window. |
 | `COMETNET_TRANSPORT_RATE_LIMIT_WINDOW` | `1.0` | Window size (seconds). |
@@ -460,6 +461,7 @@ CometNet requires an accurate system clock for cryptographic signature validatio
 ### High Memory/CPU
 
 1. Reduce `COMETNET_MAX_PEERS` (fewer connections = less overhead).
+2. Keep `COMETNET_TRANSPORT_WEBSOCKET_COMPRESSION_ENABLED=False` to avoid synchronous WebSocket compression work.
 3. Increase `COMETNET_GOSSIP_INTERVAL` (less frequent gossiping).
 
 ### Logs and Debugging


### PR DESCRIPTION
Gossip messages consist almost entirely of hex encoded cryptographic material, signatures, public keys, and infohashes. This is high entropy data that deflate cannot meaningfully compress, while the compression runs synchronously on the asyncio event loop, blocking all other work for the duration.

Disabling `permessage_deflate` on both the server and outbound client connections eliminates this overhead entirely. The wire size increase is negligible given the incompressible nature of the payload.

Compression is negotiated per connection during the WebSocket handshake so this is backwards compatible with peers that still have it enabled.

Notes:
In a 30 second py-spy sampling profile, `websockets.extensions.permessage_deflate.encode` accounted for 1.53s cumulative sampled time (~17%) in the gossip send path. This PR removes it outright, though an alternative would be lowering the compression level.

A longer term wire size improvement worth considering would be that contributor fields (`contributor_id`, `contributor_public_key`) are currently repeated on every torrent in an announce rather than being grouped by contributor. These are identical for all torrents originating from the same node, so a contributor lookup table at the message level would significantly reduce payload size, though this would require protocol version negotiation. It also assumes that the time spent encoding isn't just due to the amount of gossip itself.

The other profiled bottleneck worth flagging is the two pass serialization cycle when repropagating gossip. msgpack deserializes incoming bytes to an intermediate Python dict, Pydantic constructs typed objects from it, then on the send side Pydantic dumps back to a dict before msgpack reserializes. Replacing pydantic + msgpack with msgspec in the protocol hot path would collapse each direction into a single C call with no intermediate Python objects, the wire format stays identical msgpack so no negotiation is needed. I decided not to mess with this since it touches the protocol and validation layers fairly deeply, and I'd rather flag it and let you decide if it's something you want to do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable toggle to enable/disable WebSocket permessage-deflate compression (defaults to off).

* **Bug Fixes**
  * Standardized WebSocket compression behavior for incoming and outgoing peer connections for consistent communication.

* **Documentation**
  * Updated docs, samples, and startup messaging to explain the compression option and its performance trade-offs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->