### PR TITLE
fix(cometnet): clarify invalid websocket proxy handshakes

### DIFF
--- a/comet/cometnet/transport.py
+++ b/comet/cometnet/transport.py
@@ -188,12 +188,7 @@ class ConnectionManager:
     _HEALTH_PATHS = frozenset(
         {
             "",
-            "/",
-            "/health",
-            "/healthz",
             "/cometnet",
-            "/cometnet/health",
-            "/cometnet/healthz",
         }
     )
     _UPGRADE_REQUIRED_HEADERS = (

--- a/comet/cometnet/transport.py
+++ b/comet/cometnet/transport.py
@@ -257,8 +257,9 @@ class ConnectionManager:
         # Check if this is a WebSocket upgrade request
         connection_header = request.headers.get("Connection", "").lower()
         upgrade_header = request.headers.get("Upgrade", "").lower()
+        ws_key = request.headers.get("Sec-WebSocket-Key", "")
 
-        if "upgrade" not in connection_header or upgrade_header != "websocket":
+        if ("upgrade" not in connection_header or upgrade_header != "websocket") and not ws_key:
             path = request.path or "/"
             path_lower = path.lower().rstrip("/")
 

--- a/comet/cometnet/transport.py
+++ b/comet/cometnet/transport.py
@@ -185,6 +185,22 @@ class ConnectionManager:
     - Periodic ping/pong for health checks
     """
 
+    _HEALTH_PATHS = frozenset(
+        {
+            "",
+            "/",
+            "/health",
+            "/healthz",
+            "/cometnet",
+            "/cometnet/health",
+            "/cometnet/healthz",
+        }
+    )
+    _UPGRADE_REQUIRED_HEADERS = (
+        ("Content-Type", "text/plain"),
+        ("Upgrade", "websocket"),
+    )
+
     # Security limits
     def __init__(
         self,
@@ -242,6 +258,24 @@ class ConnectionManager:
         # Callback when a peer connects (for Discovery notification)
         self._on_peer_connected: Optional[Callable[[str, str], Awaitable[None]]] = None
 
+    @staticmethod
+    def _header_tokens(headers: websockets.Headers, name: str) -> Set[str]:
+        return {
+            token.strip().lower()
+            for value in headers.get_all(name)
+            for token in value.split(",")
+            if token.strip()
+        }
+
+    @classmethod
+    def _upgrade_required_response(cls, body: bytes) -> Response:
+        return Response(
+            426,
+            "Upgrade Required",
+            websockets.Headers(cls._UPGRADE_REQUIRED_HEADERS),
+            body,
+        )
+
     def _process_request(self, connection, request):
         """
         Handle non-WebSocket HTTP requests gracefully.
@@ -255,27 +289,32 @@ class ConnectionManager:
             connection.real_client_ip = real_ip
 
         # Check if this is a WebSocket upgrade request
-        connection_header = request.headers.get("Connection", "").lower()
-        upgrade_header = request.headers.get("Upgrade", "").lower()
+        connection_tokens = self._header_tokens(request.headers, "Connection")
+        upgrade_tokens = self._header_tokens(request.headers, "Upgrade")
         ws_key = request.headers.get("Sec-WebSocket-Key", "")
+        is_ws_upgrade = "upgrade" in connection_tokens and "websocket" in upgrade_tokens
 
-        if ("upgrade" not in connection_header or upgrade_header != "websocket") and not ws_key:
+        if not is_ws_upgrade:
             path = request.path or "/"
             path_lower = path.lower().rstrip("/")
 
-            # Known health check paths (don't warn for these)
-            health_paths = {
-                "",
-                "/",
-                "/health",
-                "/healthz",
-                "/cometnet",
-                "/cometnet/health",
-                "/cometnet/healthz",
-            }
+            if ws_key:
+                logger.warning(
+                    "Received WebSocket handshake without required upgrade headers "
+                    f"(path={path}). If using a reverse proxy, ensure the origin "
+                    "receives 'Upgrade: websocket' and 'Connection: Upgrade'."
+                )
+                return self._upgrade_required_response(
+                    (
+                        b"WebSocket handshake reached CometNet without required "
+                        b"upgrade headers. Ensure your reverse proxy forwards or "
+                        b"recreates 'Upgrade: websocket' and 'Connection: Upgrade' "
+                        b"to the origin.\n"
+                    ),
+                )
 
             is_health_check = (
-                path_lower in health_paths
+                path_lower in self._HEALTH_PATHS
                 or path_lower.endswith("/health")
                 or path_lower.endswith("/healthz")
             )
@@ -296,15 +335,7 @@ class ConnectionManager:
                 )
             else:
                 # Other requests - return 426 Upgrade Required
-                return Response(
-                    426,
-                    "Upgrade Required",
-                    websockets.Headers(
-                        [
-                            ("Content-Type", "text/plain"),
-                            ("Upgrade", "websocket"),
-                        ]
-                    ),
+                return self._upgrade_required_response(
                     b"This is a WebSocket endpoint. Use a WebSocket client.\n",
                 )
 


### PR DESCRIPTION
## Summary

Fixes WebSocket connections being silently rejected when the server sits behind a reverse proxy that strips hop-by-hop HTTP headers before forwarding to the origin. This caused the startup reachability check to always fail for nodes using such proxies as their public endpoint.

## Problem

`Connection` and `Upgrade` are defined as hop-by-hop headers in the [HTTP spec](https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1), compliant proxies are required to consume and strip them rather than forward them. This means WebSocket upgrade requests arriving via many common proxy setups (tunnels, edge networks, certain load balancer configurations) reach the origin without these headers.

`_process_request` was detecting WebSocket upgrades exclusively by checking for these two headers. When they were absent, the connection could be misidentified as a plain HTTP request and rejected before the WebSocket handshake could complete, returning `200 OK` or `426 Upgrade Required` depending on the request path. The troubleshooting docs advise users to "ensure WebSocket headers are forwarded," but in many proxy setups this stripping is unconditional and outside the user's control. Such as with Cloudflare Tunnel.

## Fix 

Added `Sec-WebSocket-Key` as a fallback in `_process_request`.

Per [RFC 6455 Section 4.1, handshake requirement 7](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1), `Sec-WebSocket-Key` is mandatory in every WebSocket handshake and is not a hop-by-hop header, so it survives proxy forwarding intact. Its presence unambiguously identifies a WebSocket upgrade request regardless of what happened to `Connection` and `Upgrade` upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of WebSocket handshake requests to reduce false positives and negatives.
  * HTTP requests that include a WebSocket key but are not valid upgrades now return a clear "426 Upgrade Required" response and log a reverse-proxy forwarding hint.
  * Health-check endpoints continue returning 200; other non-upgrade HTTP requests are handled as upgrade-required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->