### PR TITLE
fix(ui): Offcloud now uses an API key, not email:password

### DIFF
--- a/comet/templates/index.html
+++ b/comet/templates/index.html
@@ -629,9 +629,9 @@
           },
           offcloud: {
             name: "Offcloud",
-            apiKeyUrl: "https://offcloud.com",
+            apiKeyUrl: "https://offcloud.com/#/account",
             referralUrl: null,
-            helpText: "Format: `email:password`"
+            helpText: "Format: `api-key`"
           },
           pikpak: {
             name: "PikPak",


### PR DESCRIPTION
## Problem

Offcloud reworked their API and removed the email/password web-login flow. The endpoints the old login dance relied on now 404:

- `POST /api/login` → 404
- `POST /api/key` → 404

Authentication is now done purely with the account **API key**, sent as `Authorization: Bearer <key>`. StremThru already adapted to this (it sends the configured store credential as a Bearer token and calls `/api/account/info`, `/api/cache/info`, etc.).

But the configure UI still instructs users to enter their credential as `email:password`. That string gets forwarded verbatim as the Bearer token, and Offcloud rejects it:

```
$ curl -s https://offcloud.com/api/account/info -H 'Authorization: Bearer user@example.com:password'
{"error":"NOAUTH"}   # HTTP 401

$ curl -s https://offcloud.com/api/account/info -H 'Authorization: Bearer <api-key>'
{"user_id":"...","is_premium":true,"expiration_date":"...","can_download":true}   # HTTP 200
```

So any user who follows the current instructions gets a broken Offcloud setup.

## Fix

- Change the Offcloud help text from `Format: email:password` to `Format: api-key`.
- Point `apiKeyUrl` at the Offcloud account page (`https://offcloud.com/#/account`), where the API key is shown.

Docs/UI-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Get API key" link for Offcloud to direct users to the account settings page, providing a more direct path to accessing API credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->