### PR TITLE
Fix/multi title and anime mapping

### DIFF
--- a/comet/services/anime.py
+++ b/comet/services/anime.py
@@ -535,18 +535,25 @@ class AnimeMapper:
                     if not imdb_id:
                         continue
 
+                    # Fribb stores imdb_id as a list for multi-season entries.
+                    # SQLite can't bind a list, so normalize to individual ids.
+                    imdb_ids = imdb_id if isinstance(imdb_id, list) else [imdb_id]
+
                     for provider, key in _FRIBB_PROVIDER_ORDER:
                         val = entry.get(key)
                         if val:
                             found_entry_id = lookup_map.get(f"{provider}:{val}")
                             if found_entry_id is not None:
-                                fribb_batch.append(
-                                    {
-                                        "provider": "imdb",
-                                        "provider_id": imdb_id,
-                                        "entry_id": found_entry_id,
-                                    }
-                                )
+                                for single_imdb_id in imdb_ids:
+                                    if not single_imdb_id:
+                                        continue
+                                    fribb_batch.append(
+                                        {
+                                            "provider": "imdb",
+                                            "provider_id": str(single_imdb_id),
+                                            "entry_id": found_entry_id,
+                                        }
+                                    )
                                 break
 
                     if len(fribb_batch) >= _DB_CHUNK_SIZE:

--- a/comet/services/filtering.py
+++ b/comet/services/filtering.py
@@ -1,3 +1,4 @@
+import re
 from collections import OrderedDict, defaultdict
 from threading import Event, Lock
 
@@ -21,6 +22,41 @@ else:
 
 def quick_alias_match(text_normalized: str, ez_aliases_normalized: list[str]):
     return any(alias in text_normalized for alias in ez_aliases_normalized)
+
+
+# Bracketed metadata (e.g. "[1999, BDRip]", "(S2)", "{HEVC}") that pollutes a
+# title segment and breaks RTN parsing.
+_BRACKET_CONTENT = re.compile(r"\[[^\]]*\]|\([^)]*\)|\{[^}]*\}")
+
+
+def alternate_title_match(torrent_title: str, title: str, aliases) -> bool:
+    """Match multi-title release names that RTN can't fully parse.
+
+    Releases (common for anime / RU scene) often list several titles separated
+    by "/", e.g. "Инициал «Ди» / Initial D: Second Stage / Второй этап". RTN
+    only parses the first one, so a non-English first title fails title_match.
+    Here we split on the separator, strip bracketed metadata from each segment,
+    and try to match each remaining segment against the expected title/aliases.
+    """
+    if "/" not in torrent_title:
+        return False
+
+    for segment in torrent_title.split("/"):
+        segment = _BRACKET_CONTENT.sub(" ", segment).strip()
+        if not segment:
+            continue
+
+        try:
+            parsed_segment = _parse_with_cache(segment)
+        except ValidationError:
+            continue
+
+        if parsed_segment.parsed_title and title_match(
+            title, parsed_segment.parsed_title, aliases=aliases
+        ):
+            return True
+
+    return False
 
 
 def scrub(t: str):
@@ -250,7 +286,9 @@ def filter_worker(
             scrub(torrent_title), ez_aliases_normalized
         )
         if not alias_matched:
-            if not title_match(title, parsed.parsed_title, aliases=aliases):
+            if not title_match(
+                title, parsed.parsed_title, aliases=aliases
+            ) and not alternate_title_match(torrent_title, title, aliases):
                 _log_exclusion(
                     f"❌ Rejected (Title Mismatch) | {torrent_title} | Parsed: {parsed.parsed_title} | Expected: {title}"
                 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved matching for torrent releases that include multiple title variants in a single name, reducing missed matches.

* **Bug Fixes**
  * Fixed handling of provider mappings when an IMDb reference contains multiple values, preventing failures during save and improving support for multi-season entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->