### PR TITLE
Fix/season pack episode count

### DIFF
--- a/comet/services/anime.py
+++ b/comet/services/anime.py
@@ -535,18 +535,25 @@ class AnimeMapper:
                     if not imdb_id:
                         continue
 
+                    # Fribb stores imdb_id as a list for multi-season entries.
+                    # SQLite can't bind a list, so normalize to individual ids.
+                    imdb_ids = imdb_id if isinstance(imdb_id, list) else [imdb_id]
+
                     for provider, key in _FRIBB_PROVIDER_ORDER:
                         val = entry.get(key)
                         if val:
                             found_entry_id = lookup_map.get(f"{provider}:{val}")
                             if found_entry_id is not None:
-                                fribb_batch.append(
-                                    {
-                                        "provider": "imdb",
-                                        "provider_id": imdb_id,
-                                        "entry_id": found_entry_id,
-                                    }
-                                )
+                                for single_imdb_id in imdb_ids:
+                                    if not single_imdb_id:
+                                        continue
+                                    fribb_batch.append(
+                                        {
+                                            "provider": "imdb",
+                                            "provider_id": str(single_imdb_id),
+                                            "entry_id": found_entry_id,
+                                        }
+                                    )
                                 break
 
                     if len(fribb_batch) >= _DB_CHUNK_SIZE:

--- a/comet/services/filtering.py
+++ b/comet/services/filtering.py
@@ -1,3 +1,4 @@
+import re
 from collections import OrderedDict, defaultdict
 from threading import Event, Lock
 
@@ -21,6 +22,41 @@ else:
 
 def quick_alias_match(text_normalized: str, ez_aliases_normalized: list[str]):
     return any(alias in text_normalized for alias in ez_aliases_normalized)
+
+
+# Bracketed metadata (e.g. "[1999, BDRip]", "(S2)", "{HEVC}") that pollutes a
+# title segment and breaks RTN parsing.
+_BRACKET_CONTENT = re.compile(r"\[[^\]]*\]|\([^)]*\)|\{[^}]*\}")
+
+
+def alternate_title_match(torrent_title: str, title: str, aliases) -> bool:
+    """Match multi-title release names that RTN can't fully parse.
+
+    Releases (common for anime / RU scene) often list several titles separated
+    by "/", e.g. "Инициал «Ди» / Initial D: Second Stage / Второй этап". RTN
+    only parses the first one, so a non-English first title fails title_match.
+    Here we split on the separator, strip bracketed metadata from each segment,
+    and try to match each remaining segment against the expected title/aliases.
+    """
+    if "/" not in torrent_title:
+        return False
+
+    for segment in torrent_title.split("/"):
+        segment = _BRACKET_CONTENT.sub(" ", segment).strip()
+        if not segment:
+            continue
+
+        try:
+            parsed_segment = _parse_with_cache(segment)
+        except ValidationError:
+            continue
+
+        if parsed_segment.parsed_title and title_match(
+            title, parsed_segment.parsed_title, aliases=aliases
+        ):
+            return True
+
+    return False
 
 
 def scrub(t: str):
@@ -250,7 +286,9 @@ def filter_worker(
             scrub(torrent_title), ez_aliases_normalized
         )
         if not alias_matched:
-            if not title_match(title, parsed.parsed_title, aliases=aliases):
+            if not title_match(
+                title, parsed.parsed_title, aliases=aliases
+            ) and not alternate_title_match(torrent_title, title, aliases):
                 _log_exclusion(
                     f"❌ Rejected (Title Mismatch) | {torrent_title} | Parsed: {parsed.parsed_title} | Expected: {title}"
                 )

--- a/comet/services/filtering.py
+++ b/comet/services/filtering.py
@@ -8,7 +8,7 @@ from RTN import normalize_title, parse, title_match
 from comet.core.logger import logger
 from comet.core.models import settings
 from comet.utils.languages import COUNTRY_TO_LANGUAGE
-from comet.utils.parsing import ensure_multi_language
+from comet.utils.parsing import ensure_multi_language, normalize_episode_count_pack
 
 if settings.RTN_FILTER_DEBUG:
 
@@ -273,6 +273,7 @@ def filter_worker(
                 parsed.languages.append(language)
 
         ensure_multi_language(parsed)
+        normalize_episode_count_pack(parsed, torrent_title, media_type)
 
         if remove_adult_content and parsed.adult:
             _log_exclusion(f"🔞 Rejected (Adult) | {torrent_title}")

--- a/comet/utils/parsing.py
+++ b/comet/utils/parsing.py
@@ -1,9 +1,32 @@
+import re
 from functools import lru_cache
 
 from RTN import ParsedData
 
 SCRAPE_URL_MODE_BOTH = "both"
 SCRAPE_URL_MODES = frozenset((SCRAPE_URL_MODE_BOTH, "live", "background"))
+
+# RU / anime releases mark a complete batch as "E13 of 13" / "13 из 13" — the
+# leading number is an episode *count*, not an episode index.
+_EPISODE_COUNT_PACK = re.compile(r"(?i)(\d{1,4})\s*(?:of|из)\s*(\d{1,4})")
+
+
+def normalize_episode_count_pack(parsed: ParsedData, title: str, media_type: str):
+    """Treat "N of N" / "N из N" season packs as complete seasons.
+
+    RTN misreads the batch count (e.g. "E13 of 13", "13 из 13") as a single
+    episode number, so episode-scope matching drops these full-season packs for
+    any episode other than that number. When the parsed single episode equals
+    the batch count, clear the episode list and mark the release complete so it
+    matches any requested episode within the season.
+    """
+    if media_type != "series" or not parsed.episodes or len(parsed.episodes) != 1:
+        return
+
+    match = _EPISODE_COUNT_PACK.search(title)
+    if match and parsed.episodes[0] == int(match.group(1)):
+        parsed.episodes = []
+        parsed.complete = True
 
 
 def ensure_multi_language(parsed: ParsedData):


### PR DESCRIPTION
RTN misreads the batch count in RU/anime release names (e.g. "E13 of 13",
"13 из 13") as a single episode number, so episode-scope matching dropped
these full-season packs for every episode except that number. Detect the
count-of-total pattern and, when the parsed single episode equals the batch
count, clear the episode list and mark the release complete so it matches
any requested episode within the season.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved matching for torrent titles that include multiple names separated by slashes.
  * Added better handling for season packs that use “N of M” or similar episode-count wording.

* **Bug Fixes**
  * Reduced false rejections when a release title matches through an alternate title format.
  * Improved processing of mapping data when multiple IMDb IDs are present.
  * More reliably marks season packs as complete when the episode count matches the release format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->