### PR TITLE
fix: season pack torrents not recognized as cached on debrid services

### DIFF
--- a/comet/services/debrid.py
+++ b/comet/services/debrid.py
@@ -108,9 +108,9 @@ class DebridService:
         for file in availability:
             file_season = file["season"]
             file_episode = file["episode"]
-            if (file_season is not None and file_season != season) or (
-                file_episode is not None and file_episode != episode
-            ):
+            if file_season is not None and file_season != season:
+                continue
+            if episode is not None and file_episode is not None and file_episode != episode:
                 continue
 
             info_hash = file["info_hash"]
@@ -122,19 +122,20 @@ class DebridService:
                 if torrent is None:
                     continue
 
-                merged_parsed = self._merge_parsed(
-                    torrent.get("parsed"), file["parsed"]
-                )
-                if merged_parsed is not None:
-                    torrent["parsed"] = merged_parsed
+                if episode is not None:
+                    merged_parsed = self._merge_parsed(
+                        torrent.get("parsed"), file["parsed"]
+                    )
+                    if merged_parsed is not None:
+                        torrent["parsed"] = merged_parsed
 
-                file_index = self._coerce_file_index(file["index"])
-                if file_index is not None:
-                    torrent["fileIndex"] = file_index
-                if file["title"] is not None:
-                    torrent["title"] = file["title"]
-                if file["size"] is not None:
-                    torrent["size"] = file["size"]
+                    file_index = self._coerce_file_index(file["index"])
+                    if file_index is not None:
+                        torrent["fileIndex"] = file_index
+                    if file["title"] is not None:
+                        torrent["title"] = file["title"]
+                    if file["size"] is not None:
+                        torrent["size"] = file["size"]
 
         asyncio.create_task(cache_availability(self.debrid_service, availability))
         return cached_hashes
@@ -158,23 +159,24 @@ class DebridService:
                 if torrent is None:
                     continue
 
-                file_index = self._coerce_file_index(row["file_index"])
-                if file_index is not None:
-                    torrent["fileIndex"] = file_index
+                if episode is not None:
+                    file_index = self._coerce_file_index(row["file_index"])
+                    if file_index is not None:
+                        torrent["fileIndex"] = file_index
 
-                if row["size"] is not None:
-                    torrent["size"] = row["size"]
+                    if row["size"] is not None:
+                        torrent["size"] = row["size"]
 
-                if row["parsed"] is not None:
-                    cached_parsed = ParsedData(**orjson.loads(row["parsed"]))
-                    merged_parsed = self._merge_parsed(
-                        torrent.get("parsed"), cached_parsed
-                    )
-                    if merged_parsed is not None:
-                        torrent["parsed"] = merged_parsed
+                    if row["parsed"] is not None:
+                        cached_parsed = ParsedData(**orjson.loads(row["parsed"]))
+                        merged_parsed = self._merge_parsed(
+                            torrent.get("parsed"), cached_parsed
+                        )
+                        if merged_parsed is not None:
+                            torrent["parsed"] = merged_parsed
 
-                if row["title"] is not None:
-                    torrent["title"] = row["title"]
+                    if row["title"] is not None:
+                        torrent["title"] = row["title"]
 
         return cached_hashes
 

--- a/comet/services/debrid_cache.py
+++ b/comet/services/debrid_cache.py
@@ -118,16 +118,18 @@ async def get_cached_availability(
         AND updated_at >= :min_timestamp
     """
 
+    scope_params = build_scope_lookup_params(season, episode)
     params = {
         "info_hashes": encode_json_param(info_hashes),
         "min_timestamp": min_timestamp,
-        **build_scope_lookup_params(season, episode),
+        "season_norm": scope_params["season_norm"],
     }
 
     base_from_where += " AND debrid_service = :debrid_service"
     params["debrid_service"] = debrid_service
 
     if debrid_service == "offcloud":
+        params["episode_norm"] = scope_params["episode_norm"]
         query = f"""
             SELECT info_hash, file_index, title, size, parsed
             FROM (
@@ -153,10 +155,14 @@ async def get_cached_availability(
         """
         results = await database.fetch_all(query, params)
     else:
+        episode_filter = "AND episode_norm = CAST(:episode_norm AS INTEGER)" if episode is not None else ""
+        if episode is not None:
+            params["episode_norm"] = scope_params["episode_norm"]
         query = f"""
             {select_clause}
             {base_from_where}
-            AND {SCOPE_FILTER_SQL}
+            AND season_norm = CAST(:season_norm AS INTEGER)
+            {episode_filter}
         """
         results = await database.fetch_all(query, params)
 
@@ -167,19 +173,24 @@ async def get_cached_availability_any_service(
     info_hashes: list, season: int = None, episode: int = None
 ):
     min_timestamp = time.time() - settings.DEBRID_CACHE_TTL
+
+    episode_filter = "AND episode_norm = CAST(:episode_norm AS INTEGER)" if episode is not None else ""
     base_from_where = f"""
         FROM debrid_availability
         WHERE {INFO_HASH_MEMBERSHIP_SQL}
         AND updated_at >= :min_timestamp
         AND season_norm = :season_norm
-        AND episode_norm = :episode_norm
+        {episode_filter}
     """
 
+    scope_params = build_scope_lookup_params(season, episode)
     params = {
         "info_hashes": encode_json_param(info_hashes),
         "min_timestamp": min_timestamp,
-        **build_scope_lookup_params(season, episode),
+        "season_norm": scope_params["season_norm"],
     }
+    if episode is not None:
+        params["episode_norm"] = scope_params["episode_norm"]
 
     query = f"""
         SELECT info_hash, file_index, title, size, parsed


### PR DESCRIPTION
Fixes #599

When searching for a season pack (episode=None), the debrid cache check filtered entries by episode_norm=-1, but season pack torrents' cached files have episode_norm=1,2,3... (individual episode files). This meant no cached entries were found for season packs, and with cachedOnly=true, no results appeared.

## Changes

### debrid_cache.py
- `get_cached_availability`: conditionally include `episode_norm` in SQL and params only when `episode is not None`. For season pack searches (`episode=None`), the query no longer filters by `episode_norm`, allowing individual-episode cached files to match the season-level scope.
- `get_cached_availability_any_service`: same fix applied for consistency.

### debrid.py
- `get_and_cache_availability`: split the OR filter into two separate checks. The episode check now guards behind `if episode is not None` - when searching by season, individual episode files within a season pack torrent pass through and the torrent is marked as cached.
- `get_and_cache_availability`: wrap metadata overwrites (parsed, fileIndex, title, size) behind `if episode is not None` - prevents cached individual-episode data from contaminating the season pack's original metadata.
- `check_existing_availability`: same metadata guard applied to the cached-check path.