### PR TITLE
fix(cometnet): add end-to-end IPv6 support

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -416,7 +416,7 @@ COMETNET_MIN_PEERS=3 # Minimum desired peers (will actively discover if below th
 
 # === IDENTITY & SECURITY ===
 COMETNET_KEYS_DIR=data/cometnet # Directory to store P2P identity keys and state
-COMETNET_ADVERTISE_URL= # Public URL to advertise to peers (e.g. wss://comet.example.com/cometnet/ws). Required if behind reverse proxy/domain.
+COMETNET_ADVERTISE_URL= # Public URL advertised to peers (e.g. wss://comet.example.com/cometnet/ws or ws://[2001:db8::1]:8765). Required behind a reverse proxy/domain.
 COMETNET_NODE_ALIAS= # Optional friendly name for this node (exchanged with other peers)
 COMETNET_KEY_PASSWORD= # Optional password to encrypt the private key on disk
 

--- a/comet/cometnet/discovery.py
+++ b/comet/cometnet/discovery.py
@@ -201,10 +201,7 @@ class DiscoveryService:
         self, address: str, node_id: Optional[str] = None, source: str = "unknown"
     ) -> None:
         """Add a peer to the known peers list."""
-        # Normalize address
         address = address.strip()
-        if not address.startswith("ws://") and not address.startswith("wss://"):
-            address = f"ws://{address}"
 
         if address not in self._known_peers:
             self._known_peers[address] = KnownPeer(

--- a/comet/cometnet/manager.py
+++ b/comet/cometnet/manager.py
@@ -50,6 +50,7 @@ from comet.cometnet.transport import ConnectionManager
 from comet.cometnet.utils import (
     check_advertise_url_reachability,
     check_system_clock_sync,
+    format_websocket_url,
     is_internal_domain,
     is_private_or_internal_ip,
     shutdown_crypto_executor,
@@ -366,7 +367,9 @@ class CometNetService(CometNetBackend):
             if external_ip:
                 # If we successfully mapped a port and don't have an advertise URL, use the IP
                 if not self.advertise_url:
-                    self.advertise_url = f"ws://{external_ip}:{self.listen_port}"
+                    self.advertise_url = format_websocket_url(
+                        external_ip, self.listen_port
+                    )
                     # Update transport with new URL
                     self.transport.advertise_url = self.advertise_url
                     logger.log(
@@ -383,7 +386,7 @@ class CometNetService(CometNetBackend):
             try:
                 parsed = urlparse(self.advertise_url)
                 host = (parsed.hostname or "").lower()
-                local_hosts = {"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"}
+                local_hosts = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
                 is_local = host in local_hosts
             except Exception:
                 is_local = False

--- a/comet/cometnet/standalone.py
+++ b/comet/cometnet/standalone.py
@@ -492,7 +492,7 @@ class StandaloneCometNet:
         """Run the standalone server."""
         config = uvicorn.Config(
             self.app,
-            host="0.0.0.0",
+            host=None,
             port=self.http_port,
             log_config=None,
             access_log=False,

--- a/comet/cometnet/transport.py
+++ b/comet/cometnet/transport.py
@@ -33,8 +33,10 @@ from comet.cometnet.protocol import (
 )
 from comet.cometnet.utils import (
     extract_ip_from_address,
+    format_websocket_url,
     get_websocket_compression,
     is_valid_peer_address,
+    replace_websocket_url_port,
 )
 from comet.cometnet.validation import validate_message_security
 from comet.core.logger import logger
@@ -104,7 +106,6 @@ class PeerConnection:
     connected_at: float = field(default_factory=time.time)
     last_activity: float = field(default_factory=time.time)
     is_outbound: bool = True  # True if we initiated the connection
-    listen_port: int = 0  # Port where this peer accepts connections
     pending_pings: Dict[str, float] = field(default_factory=dict)  # nonce -> sent_time
     latency_ms: float = 0.0
     latency_samples: deque = field(
@@ -375,18 +376,6 @@ class ConnectionManager:
         conn = self._connections.get(node_id)
         if not conn:
             return None
-
-        # If we have a listen port (from handshake), prefer it over the socket port
-        # This ensures PEX shares the correct connectable address
-        if conn.listen_port > 0:
-            try:
-                scheme = "wss" if conn.address.startswith("wss://") else "ws"
-                clean = conn.address.replace(f"{scheme}://", "")
-                host = clean.split(":")[0]
-                return f"{scheme}://{host}:{conn.listen_port}"
-            except Exception:
-                pass
-
         return conn.address
 
     def register_handler(self, msg_type: MessageType, handler: MessageHandler) -> None:
@@ -404,8 +393,8 @@ class ConnectionManager:
         try:
             self._server = await websockets.serve(
                 self._handle_ws_connection,
-                "0.0.0.0",
-                self.listen_port,
+                host=None,
+                port=self.listen_port,
                 ping_interval=None,
                 ping_timeout=None,
                 max_size=self.max_message_size,
@@ -447,7 +436,7 @@ class ConnectionManager:
             remote = websocket.remote_address
             if remote:
                 client_ip = remote[0]
-                connectable_address = f"ws://{remote[0]}:{remote[1]}"
+                connectable_address = format_websocket_url(remote[0], remote[1])
             else:
                 client_ip = "unknown"
 
@@ -594,19 +583,22 @@ class ConnectionManager:
             return None
 
         ip = client_ip
+        parsed_ip = None
+        try:
+            parsed_ip = ipaddress.ip_address(ip)
+            if isinstance(parsed_ip, ipaddress.IPv6Address) and parsed_ip.ipv4_mapped:
+                parsed_ip = parsed_ip.ipv4_mapped
+            ip = str(parsed_ip)
+        except ValueError:
+            pass
 
         # Use lock to prevent race condition on connection limits
         async with self._connection_lock:
             # Check per-IP connection limit (prevent Sybil-like attacks)
             # Relax limit for private IPs (local network, Docker)
             limit = self.max_connections_per_ip
-            try:
-                if ipaddress.ip_address(ip).is_private:
-                    limit = max(
-                        limit, 50
-                    )  # Allow more connections from local/private IPs
-            except ValueError:
-                pass  # Not an IP address (hostname)
+            if parsed_ip is not None and parsed_ip.is_private:
+                limit = max(limit, 50)  # Allow more connections from private IPs
 
             current_ip_connections = self._connections_per_ip.get(ip, 0)
             if current_ip_connections >= limit:
@@ -629,7 +621,7 @@ class ConnectionManager:
         try:
             # Perform handshake (we wait for their handshake first)
             node_id = await self._perform_handshake(
-                websocket, client_ip, connectable_address, is_outbound=False
+                websocket, ip, connectable_address, is_outbound=False
             )
         finally:
             async with self._connection_lock:
@@ -801,9 +793,15 @@ class ConnectionManager:
                     )
                     return None
 
+            fallback_address = connectable_address
+            if not is_outbound and fallback_address and peer_handshake.listen_port > 0:
+                fallback_address = replace_websocket_url_port(
+                    fallback_address, peer_handshake.listen_port
+                )
+
             effective_address = await resolve_effective_peer_address(
                 peer_handshake.public_url,
-                connectable_address,
+                fallback_address,
                 allow_private=(
                     self._private_network or settings.COMETNET_ALLOW_PRIVATE_PEX
                 ),
@@ -817,7 +815,6 @@ class ConnectionManager:
                 client_ip=client_ip,
                 public_key=peer_handshake.public_key,
                 is_outbound=is_outbound,
-                listen_port=peer_handshake.listen_port,
                 alias=peer_handshake.alias,
             )
             # Atomically bind the verified identity to one live connection. The

--- a/comet/cometnet/utils.py
+++ b/comet/cometnet/utils.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from functools import partial
 from typing import Any, Callable, List, Optional, Tuple, TypeVar
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 import aiohttp
 import websockets
@@ -25,6 +25,32 @@ from comet.core.models import settings
 T = TypeVar("T")
 
 _crypto_executor: Optional[ThreadPoolExecutor] = None
+
+
+def _format_host_port(host: str, port: int) -> str:
+    """Format a host and port as a URI authority."""
+    return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+
+
+def format_websocket_url(host: str, port: int, scheme: str = "ws") -> str:
+    """Build a WebSocket URL, adding the brackets required around IPv6 hosts."""
+    return f"{scheme}://{_format_host_port(host, port)}"
+
+
+def replace_websocket_url_port(address: str, port: int) -> str:
+    """Replace a WebSocket URL's port without losing its IPv6 host or path."""
+    parsed = urlsplit(address)
+    if parsed.scheme not in ("ws", "wss") or not parsed.hostname:
+        raise ValueError("address must be a WebSocket URL with a hostname")
+    return urlunsplit(
+        (
+            parsed.scheme,
+            _format_host_port(parsed.hostname, port),
+            parsed.path,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
 
 
 def get_websocket_compression() -> Optional[str]:
@@ -180,12 +206,18 @@ def extract_ip_from_address(address: str) -> str:
     """
     try:
         address = address.strip()
-        # Handle ws:// or wss:// URLs
         if address.startswith(("ws://", "wss://")):
             parsed = urlparse(address)
             return parsed.hostname or "unknown"
-        # Handle raw IP:port or just IP
-        return address.split(":")[0]
+
+        # A bare IPv6 address contains colons but no port delimiter.
+        try:
+            return str(ipaddress.ip_address(address))
+        except ValueError:
+            pass
+
+        # Prefixing // makes urlsplit parse raw host:port authorities.
+        return urlsplit(f"//{address}").hostname or "unknown"
     except Exception:
         return "unknown"
 

--- a/comet/cometnet/utils.py
+++ b/comet/cometnet/utils.py
@@ -29,6 +29,8 @@ _crypto_executor: Optional[ThreadPoolExecutor] = None
 
 def _format_host_port(host: str, port: int) -> str:
     """Format a host and port as a URI authority."""
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
     return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
 
 

--- a/docs/cometnet/cometnet.md
+++ b/docs/cometnet/cometnet.md
@@ -152,7 +152,7 @@ CometNet uses two methods to find peers:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `COMETNET_KEYS_DIR` | `data/cometnet` | Directory to store your node's identity keys. |
-| `COMETNET_ADVERTISE_URL` | *(empty)* | **Required if behind a reverse proxy.** Your public WebSocket URL (e.g., `wss://comet.example.com/cometnet/ws`). |
+| `COMETNET_ADVERTISE_URL` | *(empty)* | **Required if behind a reverse proxy.** Your public WebSocket URL (e.g., `wss://comet.example.com/cometnet/ws` or `ws://[2001:db8::1]:8765` for IPv6). |
 | `COMETNET_NODE_ALIAS` | *(empty)* | Optional friendly name for your node. Shared with peers for identification. |
 | `COMETNET_KEY_PASSWORD` | *(empty)* | Optional password to encrypt your private key on disk. |
 

--- a/docs/cometnet/quickstart.md
+++ b/docs/cometnet/quickstart.md
@@ -89,6 +89,8 @@ If exposing the port directly:
 
 ```env
 COMETNET_ADVERTISE_URL=ws://YOUR_PUBLIC_IP:8765
+# IPv6 literals must be enclosed in brackets:
+COMETNET_ADVERTISE_URL=ws://[2001:db8::1]:8765
 ```
 
 ### Step 4: Open the firewall

--- a/tests/test_cometnet_api_contract.py
+++ b/tests/test_cometnet_api_contract.py
@@ -90,6 +90,28 @@ class CometNetEndpointErrorTests(unittest.IsolatedAsyncioTestCase):
 
 
 class CometNetStandaloneLifespanTests(unittest.IsolatedAsyncioTestCase):
+    async def test_http_api_listens_on_all_available_address_families(self):
+        standalone = object.__new__(StandaloneCometNet)
+        standalone.app = object()
+        standalone.http_port = 8766
+        server = Mock(serve=AsyncMock())
+
+        with (
+            patch(
+                "comet.cometnet.standalone.uvicorn.Config",
+                return_value=object(),
+            ) as config,
+            patch(
+                "comet.cometnet.standalone.uvicorn.Server",
+                return_value=server,
+            ),
+        ):
+            await standalone.run()
+
+        self.assertIsNone(config.call_args.kwargs["host"])
+        self.assertEqual(config.call_args.kwargs["port"], standalone.http_port)
+        server.serve.assert_awaited_once_with()
+
     async def test_partial_startup_failure_runs_every_registered_cleanup(self):
         standalone = object.__new__(StandaloneCometNet)
         standalone.ws_port = 8765

--- a/tests/test_cometnet_transport.py
+++ b/tests/test_cometnet_transport.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from comet.cometnet.protocol import HandshakeMessage, PingMessage
 from comet.cometnet.transport import ConnectionManager, NodeIdentity, PeerConnection
@@ -62,6 +62,106 @@ class CometNetTransportTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(manager._running)
         self.assertEqual(manager._tasks, set())
+
+    async def test_server_listens_on_all_available_address_families(self):
+        manager = ConnectionManager(_Identity())
+        server = Mock(wait_closed=AsyncMock())
+
+        with patch(
+            "comet.cometnet.transport.websockets.serve",
+            new=AsyncMock(return_value=server),
+        ) as serve:
+            await manager.start()
+            await manager.stop()
+
+        self.assertIsNone(serve.await_args.kwargs["host"])
+        self.assertEqual(serve.await_args.kwargs["port"], manager.listen_port)
+        server.close.assert_called_once_with()
+        server.wait_closed.assert_awaited_once_with()
+
+    async def test_native_ipv6_peer_address_is_a_valid_websocket_url(self):
+        manager = ConnectionManager(_Identity())
+        websocket = AsyncMock()
+        websocket.real_client_ip = None
+        websocket.remote_address = ("2001:db8::1", 49152, 0, 0)
+
+        with patch.object(
+            manager,
+            "handle_incoming_connection",
+            new=AsyncMock(return_value=None),
+        ) as handle:
+            await manager._handle_ws_connection(websocket)
+
+        handle.assert_awaited_once_with(
+            websocket,
+            "2001:db8::1",
+            "ws://[2001:db8::1]:49152",
+        )
+
+    async def test_inbound_ipv6_fallback_uses_advertised_listen_port(self):
+        manager = ConnectionManager(_Identity())
+        manager._running = True
+        handshake = HandshakeMessage(
+            sender_id="peer",
+            public_key="peer-key",
+            signature="signature",
+            listen_port=8765,
+        )
+        websocket = AsyncMock()
+        websocket.recv.return_value = handshake.to_bytes()
+
+        with (
+            patch.object(
+                NodeIdentity,
+                "verify_hex_async",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                NodeIdentity,
+                "node_id_from_public_key",
+                return_value="peer",
+            ),
+        ):
+            node_id = await manager.handle_incoming_connection(
+                websocket,
+                "2001:db8::1",
+                "ws://[2001:db8::1]:49152",
+            )
+
+        self.assertEqual(node_id, "peer")
+        self.assertEqual(
+            manager.get_peer_address("peer"),
+            "ws://[2001:db8::1]:8765",
+        )
+        await manager.stop()
+
+    async def test_equivalent_ipv6_spellings_share_connection_limit(self):
+        manager = ConnectionManager(_Identity())
+        manager._running = True
+        manager.max_connections_per_ip = 1
+        manager._connections_per_ip["2606:4700:4700::1111"] = 1
+        websocket = AsyncMock()
+
+        node_id = await manager.handle_incoming_connection(
+            websocket,
+            "2606:4700:4700:0:0:0:0:1111",
+        )
+
+        self.assertIsNone(node_id)
+        websocket.close.assert_awaited_once_with()
+
+    def test_get_peer_address_preserves_authoritative_public_url(self):
+        manager = ConnectionManager(_Identity())
+        manager._connections["peer"] = PeerConnection(
+            node_id="peer",
+            address="wss://[2001:db8::1]/cometnet/ws",
+            websocket=object(),
+        )
+
+        self.assertEqual(
+            manager.get_peer_address("peer"),
+            "wss://[2001:db8::1]/cometnet/ws",
+        )
 
     async def test_outbound_handshake_reserves_global_capacity(self):
         manager = ConnectionManager(_Identity(), max_peers=1)

--- a/tests/test_cometnet_utils.py
+++ b/tests/test_cometnet_utils.py
@@ -13,6 +13,7 @@ class CometNetUtilsTests(unittest.TestCase):
             ("192.0.2.1", 8765, "ws", "ws://192.0.2.1:8765"),
             ("peer.example", 443, "wss", "wss://peer.example:443"),
             ("2001:db8::1", 8765, "ws", "ws://[2001:db8::1]:8765"),
+            ("[2001:db8::1]", 8765, "ws", "ws://[2001:db8::1]:8765"),
             ("fe80::1%eth0", 8765, "ws", "ws://[fe80::1%eth0]:8765"),
         ]
         for host, port, scheme, expected in cases:

--- a/tests/test_cometnet_utils.py
+++ b/tests/test_cometnet_utils.py
@@ -1,0 +1,44 @@
+import unittest
+
+from comet.cometnet.utils import (
+    extract_ip_from_address,
+    format_websocket_url,
+    replace_websocket_url_port,
+)
+
+
+class CometNetUtilsTests(unittest.TestCase):
+    def test_format_websocket_url_supports_ipv4_hostname_and_ipv6(self):
+        cases = [
+            ("192.0.2.1", 8765, "ws", "ws://192.0.2.1:8765"),
+            ("peer.example", 443, "wss", "wss://peer.example:443"),
+            ("2001:db8::1", 8765, "ws", "ws://[2001:db8::1]:8765"),
+            ("fe80::1%eth0", 8765, "ws", "ws://[fe80::1%eth0]:8765"),
+        ]
+        for host, port, scheme, expected in cases:
+            with self.subTest(host=host):
+                self.assertEqual(
+                    format_websocket_url(host, port, scheme),
+                    expected,
+                )
+
+    def test_replace_websocket_url_port_preserves_ipv6_and_url_suffix(self):
+        self.assertEqual(
+            replace_websocket_url_port(
+                "wss://[2001:db8::1]:49152/cometnet/ws?token=value",
+                8765,
+            ),
+            "wss://[2001:db8::1]:8765/cometnet/ws?token=value",
+        )
+
+    def test_extract_ip_from_address_supports_ipv6_forms(self):
+        cases = [
+            ("wss://[2001:db8::1]:8765/cometnet/ws", "2001:db8::1"),
+            ("[2001:db8::1]:8765", "2001:db8::1"),
+            ("2001:0db8:0:0:0:0:0:1", "2001:db8::1"),
+            ("ws://192.0.2.1:8765", "192.0.2.1"),
+            ("peer.example:8765", "peer.example"),
+        ]
+        for address, expected in cases:
+            with self.subTest(address=address):
+                self.assertEqual(extract_ip_from_address(address), expected)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket URL/address parsing and normalization for IPv4, IPv6 (including bracketed forms), and hostnames, including safe port replacement while preserving path/query.
  - Refined peer address handling and inbound connection limit logic, including IPv4-mapped IPv6 handling and updated listen-port fallback behavior.
  - Adjusted server binding and UPnP-based advertise URL setup; improved IPv6 loopback treatment in warnings.

- **Documentation**
  - Clarified `COMETNET_ADVERTISE_URL` IPv6 bracket formatting and expanded IPv6 URL examples; updated reverse-proxy wording in the sample.

- **Tests**
  - Added/expanded unit and transport tests for URL utilities, IPv6 behaviors, and server startup configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->