### PR TITLE
feat(scraper): add context-aware timeout policies

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -89,7 +89,11 @@ DEBRID_CACHE_TTL=86400  # 1 day
 DEBRID_CACHE_CHECK_RATIO=0.0  # Minimum ratio (0.5 = 5%) of cached torrents/total torrents required to skip re-checking availability on the debrid service.
 METRICS_CACHE_TTL=60  # 1 minute
 SCRAPE_LOCK_TTL=300  # 5 minutes - Duration for distributed scraping locks
-SCRAPE_WAIT_TIMEOUT=30  # 30 seconds - Max time to wait for other instance to complete scraping
+LIVE_SCRAPE_TIMEOUT=30 # Max runtime for each scraper during synchronous requests
+BACKGROUND_SCRAPE_TIMEOUT=30 # Max runtime for each scraper during background jobs
+# Optional JSON overrides. Resolution order: scraper:context, scraper, context default.
+# Canonical scraper names are case-insensitive; the "Scraper" suffix is optional.
+SCRAPER_TIMEOUT_OVERRIDES={} # Example: {"Zilean":90,"Jackett:live":20,"Jackett:background":120}
 
 # ======================================================= #
 # Background Scraper                                      #

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, BackgroundTasks, Request
 from comet.core.config_validation import config_check
 from comet.core.logger import logger
 from comet.core.models import settings
+from comet.core.scrape import ScrapeContext
 from comet.debrid.exceptions import DebridAuthError
 from comet.debrid.manager import get_debrid_extension
 from comet.metadata.episode_index import EpisodeIndexService
@@ -279,7 +280,7 @@ async def background_scrape(
         return
 
     async def run_scrape():
-        await torrent_manager.scrape_torrents()
+        await torrent_manager.scrape_torrents(ScrapeContext.BACKGROUND)
 
         if debrid_entries and len(torrent_manager.torrents) > 0:
             await get_and_cache_multi_service_availability(
@@ -756,7 +757,7 @@ async def stream(
         try:
             if use_account_scrape:
                 scrape_result, warmup_result = await asyncio.gather(
-                    torrent_manager.scrape_torrents(),
+                    torrent_manager.scrape_torrents(ScrapeContext.LIVE),
                     ensure_account_snapshot_ready(session, debrid_entries, ip),
                     return_exceptions=True,
                 )
@@ -766,7 +767,7 @@ async def stream(
                     raise warmup_result
                 account_snapshot_ready = True
             else:
-                await torrent_manager.scrape_torrents()
+                await torrent_manager.scrape_torrents(ScrapeContext.LIVE)
             logger.log(
                 "SCRAPER",
                 f"📥 Torrents after global RTN filtering: {len(torrent_manager.torrents)}",

--- a/comet/background_scraper/worker.py
+++ b/comet/background_scraper/worker.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from comet.core.database import database
 from comet.core.logger import logger
 from comet.core.models import settings
+from comet.core.scrape import ScrapeContext
 from comet.metadata.manager import MetadataScraper
 from comet.services.lock import DistributedLock
 from comet.services.orchestration import TorrentManager
@@ -1272,10 +1273,9 @@ class BackgroundScraperWorker:
             episode=None,
             aliases=aliases,
             remove_adult_content=settings.REMOVE_ADULT_CONTENT,
-            context="background",
         )
 
-        await manager.scrape_torrents()
+        await manager.scrape_torrents(ScrapeContext.BACKGROUND)
         torrents_found = len(manager.torrents)
         if torrents_found > 0:
             await self._seed_media_demand(media_id)
@@ -1328,9 +1328,8 @@ class BackgroundScraperWorker:
                     episode=episode_number,
                     aliases=aliases,
                     remove_adult_content=settings.REMOVE_ADULT_CONTENT,
-                    context="background",
                 )
-                await manager.scrape_torrents()
+                await manager.scrape_torrents(ScrapeContext.BACKGROUND)
                 episode_torrents = len(manager.torrents)
                 success = episode_torrents > 0
             except Exception as e:

--- a/comet/core/logger.py
+++ b/comet/core/logger.py
@@ -403,7 +403,18 @@ def log_startup_info(settings):
     logger.log("COMET", f"Magnet Resolve Timeout: {settings.MAGNET_RESOLVE_TIMEOUT}s")
     logger.log("COMET", f"Catalog Timeout: {settings.CATALOG_TIMEOUT}s")
     logger.log("COMET", f"Scrape Lock TTL: {settings.SCRAPE_LOCK_TTL}s")
-    logger.log("COMET", f"Scrape Wait Timeout: {settings.SCRAPE_WAIT_TIMEOUT}s")
+    logger.log(
+        "COMET",
+        "Scrape Timeouts: "
+        f"live={settings.LIVE_SCRAPE_TIMEOUT:g}s, "
+        f"background={settings.BACKGROUND_SCRAPE_TIMEOUT:g}s",
+    )
+    if settings.SCRAPER_TIMEOUT_OVERRIDES:
+        overrides = ", ".join(
+            f"{selector}={timeout:g}s"
+            for selector, timeout in sorted(settings.SCRAPER_TIMEOUT_OVERRIDES.items())
+        )
+        logger.log("COMET", f"Scraper Timeout Overrides: {overrides}")
     logger.log("COMET", f"Download Torrent Files: {settings.DOWNLOAD_TORRENT_FILES}")
 
     comet_url = (

--- a/comet/core/models.py
+++ b/comet/core/models.py
@@ -29,6 +29,7 @@ from RTN.models import (
 
 from comet.core.db_router import ReplicaAwareDatabase
 from comet.core.logger import logger
+from comet.core.scrape import normalize_scraper_timeout_selector
 
 _comet_fk_enabled = False
 _SQLITE_BUSY_TIMEOUT_MS = 30000
@@ -64,6 +65,10 @@ _POSITIVE_WORK_COUNT_FIELDS = (
     "BITMAGNET_MAX_CONCURRENT_PAGES",
     "BACKGROUND_SCRAPER_CONCURRENT_WORKERS",
     "FILTER_PARSE_CACHE_SHARDS",
+)
+_SCRAPE_TIMEOUT_FIELDS = (
+    "LIVE_SCRAPE_TIMEOUT",
+    "BACKGROUND_SCRAPE_TIMEOUT",
 )
 _POSITIVE_COMETNET_OPERATION_FIELDS = (
     "COMETNET_MAX_PEERS",
@@ -172,9 +177,9 @@ class AppSettings(BaseSettings):
     METRICS_CACHE_TTL: Optional[int] = 60  # 1 minute
     DEBRID_CACHE_CHECK_RATIO: Optional[float] = 0.0  # 0.0 to 1.0
     SCRAPE_LOCK_TTL: Optional[int] = 300  # 5 minutes
-    SCRAPE_WAIT_TIMEOUT: Optional[int] = (
-        30  # Max time to wait for other instance to complete
-    )
+    LIVE_SCRAPE_TIMEOUT: float = 30.0
+    BACKGROUND_SCRAPE_TIMEOUT: float = 30.0
+    SCRAPER_TIMEOUT_OVERRIDES: dict[str, float] = Field(default_factory=dict)
     INDEXER_MANAGER_TYPE: Optional[str] = None
     INDEXER_MANAGER_URL: Optional[str] = "http://127.0.0.1:9117"
     INDEXER_MANAGER_API_KEY: Optional[str] = None
@@ -441,6 +446,40 @@ class AppSettings(BaseSettings):
         if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
             raise ValueError("work count must be a positive integer")
         return value
+
+    @staticmethod
+    def _normalize_scrape_timeout(value) -> float:
+        if isinstance(value, bool):
+            raise ValueError("scrape timeouts must be finite numbers greater than zero")
+        try:
+            normalized = float(value)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "scrape timeouts must be finite numbers greater than zero"
+            ) from None
+        if not math.isfinite(normalized) or normalized <= 0:
+            raise ValueError("scrape timeouts must be finite numbers greater than zero")
+        return normalized
+
+    @field_validator(*_SCRAPE_TIMEOUT_FIELDS, mode="before")
+    def validate_scrape_timeout(cls, value):
+        return cls._normalize_scrape_timeout(value)
+
+    @field_validator("SCRAPER_TIMEOUT_OVERRIDES", mode="before")
+    def normalize_scraper_timeout_overrides(cls, value):
+        if not isinstance(value, dict):
+            raise ValueError("SCRAPER_TIMEOUT_OVERRIDES must be a JSON object")
+
+        normalized = {}
+        for selector, timeout in value.items():
+            normalized_selector = normalize_scraper_timeout_selector(selector)
+            if normalized_selector in normalized:
+                raise ValueError(
+                    "SCRAPER_TIMEOUT_OVERRIDES contains duplicate normalized "
+                    f"selector {normalized_selector!r}"
+                )
+            normalized[normalized_selector] = cls._normalize_scrape_timeout(timeout)
+        return normalized
 
     @field_validator(
         *_POSITIVE_WORK_COUNT_FIELDS,

--- a/comet/core/scrape.py
+++ b/comet/core/scrape.py
@@ -1,0 +1,39 @@
+from enum import StrEnum
+
+
+class ScrapeContext(StrEnum):
+    LIVE = "live"
+    BACKGROUND = "background"
+
+
+def normalize_scraper_name(name: str) -> str:
+    if type(name) is not str:
+        raise ValueError("scraper name must be a string")
+
+    normalized = name.strip().casefold()
+    if normalized.endswith("scraper"):
+        normalized = normalized.removesuffix("scraper")
+    if not normalized or not normalized.isalnum():
+        raise ValueError(f"invalid scraper name: {name!r}")
+    return normalized
+
+
+def normalize_scraper_timeout_selector(selector: str) -> str:
+    if type(selector) is not str:
+        raise ValueError("scraper timeout selector must be a string")
+
+    parts = selector.strip().split(":")
+    if len(parts) > 2:
+        raise ValueError(f"invalid scraper timeout selector: {selector!r}")
+
+    scraper_name = normalize_scraper_name(parts[0])
+    if len(parts) == 1:
+        return scraper_name
+
+    try:
+        context = ScrapeContext(parts[1].strip().casefold())
+    except ValueError:
+        raise ValueError(
+            f"invalid scraper timeout context in selector: {selector!r}"
+        ) from None
+    return f"{scraper_name}:{context.value}"

--- a/comet/scrapers/manager.py
+++ b/comet/scrapers/manager.py
@@ -25,6 +25,7 @@ ANIME_ONLY_SETTING_BY_SCRAPER = {
     "SeaDexScraper": "SEADEX_ANIME_ONLY",
     "NekoBTScraper": "NEKOBT_ANIME_ONLY",
 }
+INDEXER_MANAGER_SCRAPERS = frozenset({"jackett", "prowlarr"})
 
 
 class ScraperManager:
@@ -72,17 +73,20 @@ class ScraperManager:
     def _resolve_timeout(scraper_name: str, context: ScrapeContext) -> float:
         normalized_name = normalize_scraper_name(scraper_name)
         overrides = settings.SCRAPER_TIMEOUT_OVERRIDES
-        return overrides.get(
-            f"{normalized_name}:{context.value}",
-            overrides.get(
-                normalized_name,
-                (
-                    settings.LIVE_SCRAPE_TIMEOUT
-                    if context == ScrapeContext.LIVE
-                    else settings.BACKGROUND_SCRAPE_TIMEOUT
-                ),
-            ),
+        context_selector = f"{normalized_name}:{context.value}"
+        if context_selector in overrides:
+            return overrides[context_selector]
+        if normalized_name in overrides:
+            return overrides[normalized_name]
+
+        timeout = (
+            settings.LIVE_SCRAPE_TIMEOUT
+            if context == ScrapeContext.LIVE
+            else settings.BACKGROUND_SCRAPE_TIMEOUT
         )
+        if normalized_name in INDEXER_MANAGER_SCRAPERS:
+            timeout += max(0, settings.INDEXER_MANAGER_WAIT_TIMEOUT or 0)
+        return timeout
 
     async def _scrape_wrapper(
         self,

--- a/comet/scrapers/manager.py
+++ b/comet/scrapers/manager.py
@@ -8,6 +8,7 @@ from typing import Dict
 
 from comet.core.logger import logger
 from comet.core.models import settings
+from comet.core.scrape import ScrapeContext, normalize_scraper_name
 from comet.scrapers.base import BaseScraper
 from comet.scrapers.models import ScrapeRequest
 from comet.services.anime import anime_mapper
@@ -30,6 +31,7 @@ class ScraperManager:
     def __init__(self):
         self.scrapers: Dict[str, BaseScraper] = {}
         self.discover_scrapers()
+        self._validate_timeout_overrides()
 
     def discover_scrapers(self):
         """
@@ -53,12 +55,52 @@ class ScraperManager:
                 ):
                     self.scrapers[obj.__name__] = obj
 
+    def _validate_timeout_overrides(self) -> None:
+        available = {normalize_scraper_name(name) for name in self.scrapers}
+        configured = {
+            selector.partition(":")[0]
+            for selector in settings.SCRAPER_TIMEOUT_OVERRIDES
+        }
+        unknown = sorted(configured - available)
+        if unknown:
+            raise ValueError(
+                "SCRAPER_TIMEOUT_OVERRIDES contains unknown scrapers: "
+                + ", ".join(unknown)
+            )
+
+    @staticmethod
+    def _resolve_timeout(scraper_name: str, context: ScrapeContext) -> float:
+        normalized_name = normalize_scraper_name(scraper_name)
+        overrides = settings.SCRAPER_TIMEOUT_OVERRIDES
+        return overrides.get(
+            f"{normalized_name}:{context.value}",
+            overrides.get(
+                normalized_name,
+                (
+                    settings.LIVE_SCRAPE_TIMEOUT
+                    if context == ScrapeContext.LIVE
+                    else settings.BACKGROUND_SCRAPE_TIMEOUT
+                ),
+            ),
+        )
+
     async def _scrape_wrapper(
-        self, name: str, scraper: BaseScraper, request: ScrapeRequest
+        self,
+        name: str,
+        scraper: BaseScraper,
+        request: ScrapeRequest,
+        timeout: float,
     ):
         started_at = time.perf_counter()
         try:
-            results = await scraper.scrape(request)
+            async with asyncio.timeout(timeout):
+                results = await scraper.scrape(request)
+        except TimeoutError:
+            logger.warning(
+                f"Scraper {name} timed out "
+                f"(context={request.context.value}, budget={timeout:g}s)"
+            )
+            results = []
         except Exception as e:
             logger.warning(f"Scraper {name} failed: {e}")  # todo: better error handling
             results = []
@@ -77,7 +119,7 @@ class ScraperManager:
         for scraper_name, scraper_class in self.scrapers.items():
             # Determine if scraper should be enabled
             # Convention: Scraper class name "NyaaScraper" -> settings.SCRAPE_NYAA
-            scraper_name_clean = scraper_name.replace("Scraper", "")
+            scraper_name_clean = scraper_name.removesuffix("Scraper")
             setting_name = scraper_name_clean.upper()
             setting_key = f"SCRAPE_{setting_name}"
 
@@ -97,6 +139,8 @@ class ScraperManager:
                     )
                 if not is_anime_content:
                     continue
+
+            scrape_timeout = self._resolve_timeout(scraper_name_clean, request.context)
 
             # Get client wrapper
             client = network_manager.get_client(
@@ -120,6 +164,7 @@ class ScraperManager:
                                 f"{scraper_name_clean} #{active_instance_count}",
                                 scraper,
                                 request,
+                                scrape_timeout,
                             )
                         )
 
@@ -140,6 +185,7 @@ class ScraperManager:
                                 f"{scraper_name_clean} #{active_instance_count}",
                                 scraper,
                                 request,
+                                scrape_timeout,
                             )
                         )
 
@@ -165,12 +211,18 @@ class ScraperManager:
                                 f"{scraper_name_clean} #{active_instance_count}",
                                 scraper,
                                 request,
+                                scrape_timeout,
                             )
                         )
                 else:
                     scraper = scraper_class(self, client)
                     tasks.append(
-                        self._scrape_wrapper(scraper_name_clean, scraper, request)
+                        self._scrape_wrapper(
+                            scraper_name_clean,
+                            scraper,
+                            request,
+                            scrape_timeout,
+                        )
                     )
 
         scraper_tasks = [asyncio.create_task(task) for task in tasks]

--- a/comet/scrapers/models.py
+++ b/comet/scrapers/models.py
@@ -2,6 +2,8 @@ from typing import List, Optional, TypedDict
 
 from pydantic import BaseModel
 
+from comet.core.scrape import ScrapeContext
+
 
 class ScrapeRequest(BaseModel):
     media_type: str  # "movie" or "series"
@@ -12,7 +14,7 @@ class ScrapeRequest(BaseModel):
     year_end: Optional[int] = None
     season: Optional[int] = None
     episode: Optional[int] = None
-    context: str = "live"  # "live" or "background"
+    context: ScrapeContext = ScrapeContext.LIVE
     search_titles: tuple[str, ...] = ()
 
     @property

--- a/comet/services/orchestration.py
+++ b/comet/services/orchestration.py
@@ -5,6 +5,7 @@ from RTN import DefaultRanking, ParsedData
 from comet.core.execution import get_executor
 from comet.core.logger import logger
 from comet.core.models import CometSettingsModel, database, settings
+from comet.core.scrape import ScrapeContext
 from comet.scrapers.manager import scraper_manager
 from comet.scrapers.models import ScrapeRequest
 from comet.services.filtering import filter_worker
@@ -67,7 +68,6 @@ class TorrentManager:
         aliases: dict,
         remove_adult_content: bool,
         is_kitsu: bool = False,
-        context: str = "live",
         search_episode: int | None = None,
         search_season: int | None = None,
         cache_media_ids: list[str] | None = None,
@@ -88,8 +88,6 @@ class TorrentManager:
         self.aliases = aliases
         self.remove_adult_content = remove_adult_content
         self.is_kitsu = is_kitsu
-        self.context = context
-
         self.cache_media_ids = normalize_cache_media_ids(
             self.media_only_id, cache_media_ids
         )
@@ -123,6 +121,7 @@ class TorrentManager:
 
     async def scrape_torrents(
         self,
+        context: ScrapeContext,
     ):
         request = ScrapeRequest(
             media_type=self.media_type,
@@ -133,7 +132,7 @@ class TorrentManager:
             year_end=self.year_end,
             season=self.search_season,
             episode=self.search_episode,
-            context=self.context,
+            context=context,
             search_titles=select_indexer_titles(
                 self.title,
                 self.aliases,

--- a/comet/utils/network_manager.py
+++ b/comet/utils/network_manager.py
@@ -218,12 +218,14 @@ class AsyncClientWrapper:
         impersonate: Optional[str] = None,
         proxy_url: Optional[str] = None,
         headers: Optional[dict] = None,
-        timeout: int = 30,
+        timeout: float | None = None,
     ):
         self.scraper_name = scraper_name
         self.base_url = base_url
         self.impersonate = impersonate
-        self.timeout = timeout
+        self.timeout = (
+            settings.HTTP_CLIENT_TIMEOUT_TOTAL if timeout is None else timeout
+        )
         self.headers = headers or {}
 
         # Determine proxy configuration

--- a/docs/advanced/02-configuration-model.md
+++ b/docs/advanced/02-configuration-model.md
@@ -57,6 +57,8 @@ Behavior:
 
 5. Scrapers/indexers
 - `SCRAPE_*` flags and related URL/API key variables
+- `LIVE_SCRAPE_TIMEOUT`, `BACKGROUND_SCRAPE_TIMEOUT`
+- `SCRAPER_TIMEOUT_OVERRIDES`
 - Jackett/Prowlarr indexer manager settings
 - `INDEXER_INCLUDE_CANONICAL_TITLE`: includes Comet's canonical metadata title. Defaults to `True`.
 - `INDEXER_INCLUDE_ORIGINAL_TITLE`: includes one original TMDB or anime-mapping title. Defaults to `True`.

--- a/docs/advanced/04-scrapers-background-and-dmm.md
+++ b/docs/advanced/04-scrapers-background-and-dmm.md
@@ -21,6 +21,30 @@ Effective execution is the intersection of scraper-level mode (`SCRAPE_*`) and U
 
 Anime-only gates are enforced for specific scrapers (`NYAA_ANIME_ONLY`, `ANIMETOSHO_ANIME_ONLY`, `SEADEX_ANIME_ONLY`, `NEKOBT_ANIME_ONLY`).
 
+### Scraper Timeouts
+
+Each scraper invocation has a context-specific runtime budget:
+
+- `LIVE_SCRAPE_TIMEOUT`
+- `BACKGROUND_SCRAPE_TIMEOUT`
+
+`SCRAPER_TIMEOUT_OVERRIDES` accepts a JSON object for provider-specific tuning.
+Selectors are case-insensitive and may optionally include a `:live` or
+`:background` suffix:
+
+```env
+LIVE_SCRAPE_TIMEOUT=10
+BACKGROUND_SCRAPE_TIMEOUT=60
+SCRAPER_TIMEOUT_OVERRIDES={"Zilean":90,"Jackett:live":20}
+```
+
+Resolution order is context-specific scraper override, scraper override, then
+the context default. A timeout cancels only the affected scraper invocation;
+other providers continue and their results are retained.
+
+`HTTP_CLIENT_TIMEOUT_TOTAL` remains the timeout for one HTTP request. Scraper
+budgets cover the complete provider operation, including pagination and retries.
+
 ## Indexer Manager (Jackett/Prowlarr)
 
 `IndexerManager` periodically refreshes active indexers:

--- a/docs/advanced/04-scrapers-background-and-dmm.md
+++ b/docs/advanced/04-scrapers-background-and-dmm.md
@@ -42,6 +42,10 @@ Resolution order is context-specific scraper override, scraper override, then
 the context default. A timeout cancels only the affected scraper invocation;
 other providers continue and their results are retained.
 
+Without an explicit override, Jackett and Prowlarr also reserve
+`INDEXER_MANAGER_WAIT_TIMEOUT` for cold indexer-manager initialization before
+their context-specific scrape budget begins.
+
 `HTTP_CLIENT_TIMEOUT_TOTAL` remains the timeout for one HTTP request. Scraper
 budgets cover the complete provider operation, including pagination and retries.
 

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from unittest.mock import patch
 
+from comet.core.scrape import ScrapeContext
 from comet.services.orchestration import TorrentManager, scraper_manager, settings
 
 
@@ -37,12 +38,13 @@ class TorrentOrchestrationTests(unittest.IsolatedAsyncioTestCase):
             patch.object(manager, "cache_torrents"),
             patch("comet.services.orchestration.logger.log") as log,
         ):
-            await manager.scrape_torrents()
+            await manager.scrape_torrents(ScrapeContext.LIVE)
 
         self.assertEqual(
             captured[0].query_titles,
             ("La vita davanti a se",),
         )
+        self.assertIs(captured[0].context, ScrapeContext.LIVE)
         log.assert_any_call(
             "SCRAPER",
             "🔤 Indexer titles (1): “La vita davanti a se”",
@@ -150,7 +152,7 @@ class TorrentOrchestrationTests(unittest.IsolatedAsyncioTestCase):
             patch.object(scraper_manager, "scrape_all", new=no_scraper_results),
             patch.object(manager, "cache_torrents", new=cache_torrents),
         ):
-            scrape = asyncio.create_task(manager.scrape_torrents())
+            scrape = asyncio.create_task(manager.scrape_torrents(ScrapeContext.LIVE))
             await cache_started.wait()
             await asyncio.sleep(0)
             self.assertFalse(scrape.done())

--- a/tests/test_scraper_manager.py
+++ b/tests/test_scraper_manager.py
@@ -2,8 +2,10 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, patch
 
+from comet.core.scrape import ScrapeContext
 from comet.scrapers.manager import ScraperManager, network_manager, settings
 from comet.scrapers.models import ScrapeRequest
+from comet.utils.network_manager import AsyncClientWrapper
 
 
 class ScraperManagerTaskTests(unittest.IsolatedAsyncioTestCase):
@@ -28,12 +30,137 @@ class ScraperManagerTaskTests(unittest.IsolatedAsyncioTestCase):
             side_effect=(10.0, 10.875),
         ):
             name, results, response_time = await manager._scrape_wrapper(
-                "Example", scraper, request
+                "Example", scraper, request, timeout=30
             )
 
         self.assertEqual(name, "Example")
         self.assertEqual(results, [{"title": "Result"}])
         self.assertEqual(response_time, 0.875)
+
+    def test_timeout_resolution_uses_most_specific_override(self):
+        manager = ScraperManager.__new__(ScraperManager)
+
+        with (
+            patch.object(settings, "LIVE_SCRAPE_TIMEOUT", 10.0),
+            patch.object(settings, "BACKGROUND_SCRAPE_TIMEOUT", 60.0),
+            patch.object(
+                settings,
+                "SCRAPER_TIMEOUT_OVERRIDES",
+                {
+                    "zilean": 90.0,
+                    "jackett:live": 20.0,
+                    "jackett:background": 120.0,
+                },
+            ),
+        ):
+            self.assertEqual(
+                manager._resolve_timeout("Zilean", ScrapeContext.LIVE), 90.0
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Zilean", ScrapeContext.BACKGROUND), 90.0
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Jackett", ScrapeContext.LIVE), 20.0
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Jackett", ScrapeContext.BACKGROUND),
+                120.0,
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Torrentio", ScrapeContext.LIVE), 10.0
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Torrentio", ScrapeContext.BACKGROUND),
+                60.0,
+            )
+
+    def test_unknown_timeout_override_is_rejected(self):
+        manager = ScraperManager.__new__(ScraperManager)
+        manager.scrapers = {"ZileanScraper": object()}
+
+        with (
+            patch.object(
+                settings,
+                "SCRAPER_TIMEOUT_OVERRIDES",
+                {"unknown": 10.0},
+            ),
+            self.assertRaisesRegex(ValueError, "unknown scrapers: unknown"),
+        ):
+            manager._validate_timeout_overrides()
+
+    def test_scraper_clients_use_shared_http_request_timeout(self):
+        with (
+            patch.object(settings, "HTTP_CLIENT_TIMEOUT_TOTAL", 47.5),
+            patch.object(settings, "GLOBAL_PROXY_URL", None),
+        ):
+            client = AsyncClientWrapper("Example")
+
+        self.assertEqual(client.timeout, 47.5)
+
+    async def test_slow_scraper_timeout_preserves_fast_results(self):
+        slow_started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        class FastScraper:
+            impersonate = None
+
+            def __init__(self, manager, client, url=None):
+                del manager, client, url
+
+            async def scrape(self, request):
+                del request
+                await slow_started.wait()
+                return [{"title": "Fast result"}]
+
+        class SlowScraper:
+            impersonate = None
+
+            def __init__(self, manager, client, url=None):
+                del manager, client, url
+
+            async def scrape(self, request):
+                del request
+                slow_started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cancelled.set()
+
+        manager = ScraperManager.__new__(ScraperManager)
+        manager.scrapers = {
+            "NyaaScraper": FastScraper,
+            "ZileanScraper": SlowScraper,
+        }
+        request = ScrapeRequest(
+            media_type="movie",
+            media_id="tt123",
+            media_only_id="tt123",
+            title="Title",
+            context=ScrapeContext.BACKGROUND,
+        )
+
+        with (
+            patch.object(settings, "SCRAPE_NYAA", True),
+            patch.object(settings, "NYAA_ANIME_ONLY", False),
+            patch.object(settings, "SCRAPE_ZILEAN", True),
+            patch.object(settings, "BACKGROUND_SCRAPE_TIMEOUT", 1.0),
+            patch.object(
+                settings,
+                "SCRAPER_TIMEOUT_OVERRIDES",
+                {"zilean:background": 0.01},
+            ),
+            patch.object(network_manager, "get_client", return_value=object()),
+            patch("comet.scrapers.manager.logger.warning") as warning,
+        ):
+            results = [result async for result in manager.scrape_all(request)]
+
+        results_by_name = {name: torrents for name, torrents, _ in results}
+        self.assertEqual(results_by_name["Nyaa"], [{"title": "Fast result"}])
+        self.assertEqual(results_by_name["Zilean #1"], [])
+        self.assertTrue(cancelled.is_set())
+        warning.assert_called_once_with(
+            "Scraper Zilean #1 timed out (context=background, budget=0.01s)"
+        )
 
     async def test_closing_results_cancels_unfinished_scrapers(self):
         slow_started = asyncio.Event()

--- a/tests/test_scraper_manager.py
+++ b/tests/test_scraper_manager.py
@@ -74,6 +74,45 @@ class ScraperManagerTaskTests(unittest.IsolatedAsyncioTestCase):
                 60.0,
             )
 
+    def test_indexer_defaults_preserve_the_context_budget_after_initialization(self):
+        manager = ScraperManager.__new__(ScraperManager)
+
+        with (
+            patch.object(settings, "LIVE_SCRAPE_TIMEOUT", 10.0),
+            patch.object(settings, "BACKGROUND_SCRAPE_TIMEOUT", 60.0),
+            patch.object(settings, "INDEXER_MANAGER_WAIT_TIMEOUT", 30),
+            patch.object(settings, "SCRAPER_TIMEOUT_OVERRIDES", {}),
+        ):
+            self.assertEqual(
+                manager._resolve_timeout("Jackett", ScrapeContext.LIVE), 40.0
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Prowlarr", ScrapeContext.BACKGROUND),
+                90.0,
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Zilean", ScrapeContext.LIVE), 10.0
+            )
+
+    def test_indexer_override_replaces_the_derived_default(self):
+        manager = ScraperManager.__new__(ScraperManager)
+
+        with (
+            patch.object(settings, "LIVE_SCRAPE_TIMEOUT", 10.0),
+            patch.object(settings, "INDEXER_MANAGER_WAIT_TIMEOUT", 30),
+            patch.object(
+                settings,
+                "SCRAPER_TIMEOUT_OVERRIDES",
+                {"jackett": 15.0, "prowlarr:live": 20.0},
+            ),
+        ):
+            self.assertEqual(
+                manager._resolve_timeout("Jackett", ScrapeContext.LIVE), 15.0
+            )
+            self.assertEqual(
+                manager._resolve_timeout("Prowlarr", ScrapeContext.LIVE), 20.0
+            )
+
     def test_unknown_timeout_override_is_rejected(self):
         manager = ScraperManager.__new__(ScraperManager)
         manager.scrapers = {"ZileanScraper": object()}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -33,6 +33,48 @@ class AppSettingsTests(unittest.TestCase):
         self.assertTrue(settings.INDEXER_INCLUDE_CANONICAL_TITLE)
         self.assertTrue(settings.INDEXER_INCLUDE_ORIGINAL_TITLE)
 
+    def test_scrape_timeout_defaults_and_overrides_are_normalized(self):
+        settings = AppSettings(
+            _env_file=None,
+            SCRAPER_TIMEOUT_OVERRIDES={
+                " ZileanScraper ": 90,
+                "Jackett:LIVE": 20.5,
+            },
+        )
+
+        self.assertEqual(settings.LIVE_SCRAPE_TIMEOUT, 30.0)
+        self.assertEqual(settings.BACKGROUND_SCRAPE_TIMEOUT, 30.0)
+        self.assertEqual(
+            settings.SCRAPER_TIMEOUT_OVERRIDES,
+            {"zilean": 90.0, "jackett:live": 20.5},
+        )
+
+    def test_invalid_scrape_timeout_configuration_fails(self):
+        for field in ("LIVE_SCRAPE_TIMEOUT", "BACKGROUND_SCRAPE_TIMEOUT"):
+            for value in (True, 0, -1, float("inf"), None):
+                with self.subTest(field=field, value=value):
+                    with self.assertRaisesRegex(
+                        ValidationError,
+                        "finite numbers greater than zero",
+                    ):
+                        AppSettings(_env_file=None, **{field: value})
+
+        invalid_overrides = (
+            [],
+            {"Zilean": True},
+            {"Zilean": 0},
+            {"Zilean:batch": 10},
+            {"Zilean:live:extra": 10},
+            {"Zilean": 10, "zileanScraper": 20},
+        )
+        for overrides in invalid_overrides:
+            with self.subTest(overrides=overrides):
+                with self.assertRaises(ValidationError):
+                    AppSettings(
+                        _env_file=None,
+                        SCRAPER_TIMEOUT_OVERRIDES=overrides,
+                    )
+
     def test_indexer_languages_are_normalized_and_deduplicated(self):
         settings = AppSettings(
             _env_file=None,

--- a/tests/test_stream_scrape_context.py
+++ b/tests/test_stream_scrape_context.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from comet.api.endpoints.stream import background_scrape
+from comet.core.scrape import ScrapeContext
+
+
+class StreamScrapeContextTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cache_refresh_uses_background_context(self):
+        manager = AsyncMock()
+        manager.torrents = {}
+        lock = AsyncMock()
+        lock.acquire.return_value = True
+
+        async def run(operation):
+            return await operation
+
+        lock.run.side_effect = run
+
+        with patch(
+            "comet.api.endpoints.stream.DistributedLock",
+            return_value=lock,
+        ):
+            await background_scrape(
+                manager,
+                media_id="tt123",
+                debrid_entries=[],
+                ip="127.0.0.1",
+                session=None,
+            )
+
+        manager.scrape_torrents.assert_awaited_once_with(ScrapeContext.BACKGROUND)
+        lock.release.assert_awaited_once()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate scraper timeout settings for live vs background scraping, plus optional per-scraper/per-context timeout overrides.
  * Torrent/scrape operations now carry an explicit scrape context, ensuring timeouts apply to the correct scraping mode.

* **Bug Fixes**
  * Improved timeout validation and selector normalization for overrides.
  * Slow scraper timeouts cancel only the targeted scraper while preserving already-completed results.
  * HTTP client wrapper now uses the shared application timeout setting by default.

* **Documentation**
  * Updated configuration docs with timeout and override rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->