### PR TITLE
fix(background): calculate queue age from eligibility time

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -122,7 +122,7 @@ BACKGROUND_SCRAPER_QUEUE_LOW_WATERMARK=10000 # Resume discovery only when queue 
 BACKGROUND_SCRAPER_QUEUE_HIGH_WATERMARK=20000 # Pause discovery when queue reaches this level (hysteresis with LOW)
 BACKGROUND_SCRAPER_QUEUE_HARD_CAP=30000 # Safety cap: force discovery pause when queue reaches this level
 BACKGROUND_SCRAPER_ALERT_FAIL_RATE=0.7 # Degrade health when 24h fail rate exceeds this ratio
-BACKGROUND_SCRAPER_ALERT_QUEUE_AGE=86400 # Degrade health when oldest queued item age exceeds this (seconds)
+BACKGROUND_SCRAPER_ALERT_QUEUE_AGE=86400 # Degrade health when eligible work has waited longer than this (seconds)
 BACKGROUND_SCRAPER_RUN_RETENTION_DAYS=30 # Retention for run history table
 CATALOG_TIMEOUT=30 # Max time to fetch catalog pages (seconds)
 

--- a/comet/background_scraper/worker.py
+++ b/comet/background_scraper/worker.py
@@ -67,6 +67,26 @@ def _database_record_dict(row, field_name: str) -> dict:
         raise TypeError(f"{field_name} must be a database record") from error
 
 
+def _queue_ready_at_sql(table_alias: str) -> str:
+    created_at = f"COALESCE({table_alias}.created_at, :now)"
+    return f"""
+        CASE
+            WHEN {table_alias}.last_success_at IS NOT NULL
+             AND {table_alias}.last_success_at + :success_ttl >= {created_at}
+             AND (
+                    {table_alias}.next_retry_at IS NULL
+                    OR {table_alias}.last_success_at + :success_ttl
+                       >= {table_alias}.next_retry_at
+                 )
+            THEN {table_alias}.last_success_at + :success_ttl
+            WHEN {table_alias}.next_retry_at IS NOT NULL
+             AND {table_alias}.next_retry_at >= {created_at}
+            THEN {table_alias}.next_retry_at
+            ELSE {created_at}
+        END
+    """
+
+
 def _serialize_run_row(row) -> dict:
     candidate = _database_record_dict(row, "background scraper run")
     if set(candidate) != BACKGROUND_SCRAPER_RUN_FIELDS:
@@ -184,61 +204,66 @@ class BackgroundScraperWorker:
 
     def _queue_query_context(self, now: float | None = None):
         current_now = now if now is not None else time.time()
+        success_ttl = settings.BACKGROUND_SCRAPER_SUCCESS_TTL
         return current_now, {
             "now": current_now,
-            "success_cutoff": current_now - settings.BACKGROUND_SCRAPER_SUCCESS_TTL,
+            "success_cutoff": current_now - success_ttl,
+            "success_ttl": success_ttl,
             "max_retries": self._max_retries_for_query(),
         }
 
     async def _fetch_queue_snapshot(self, now: float | None = None):
         current_now, query_context = self._queue_query_context(now=now)
+        item_ready_at_sql = _queue_ready_at_sql("i")
+        episode_ready_at_sql = _queue_ready_at_sql("e")
 
         queue_snapshot = await database.fetch_one(
-            """
-            WITH item_snapshot AS (
+            f"""
+            WITH ready_items AS (
+                SELECT
+                    i.media_id,
+                    i.media_type,
+                    {item_ready_at_sql} AS ready_at
+                FROM background_scraper_items i
+                WHERE (i.next_retry_at IS NULL OR i.next_retry_at <= :now)
+                  AND (i.last_success_at IS NULL OR i.last_success_at <= :success_cutoff)
+                  AND (i.status != 'dead' OR i.consecutive_failures < :max_retries)
+            ),
+            item_snapshot AS (
                 SELECT
                     COALESCE(SUM(CASE WHEN media_type = 'movie' THEN 1 ELSE 0 END), 0) AS movie_count,
                     COALESCE(SUM(CASE WHEN media_type = 'series' THEN 1 ELSE 0 END), 0) AS series_count,
-                    MIN(created_at) AS oldest_item_ts
-                FROM background_scraper_items
-                WHERE (next_retry_at IS NULL OR next_retry_at <= :now)
-                  AND (last_success_at IS NULL OR last_success_at <= :success_cutoff)
-                  AND (status != 'dead' OR consecutive_failures < :max_retries)
+                    MIN(ready_at) AS oldest_item_ts
+                FROM ready_items
+            ),
+            episode_candidates AS (
+                SELECT
+                    i.ready_at AS parent_ready_at,
+                    {episode_ready_at_sql} AS episode_ready_at
+                FROM background_scraper_episodes e
+                JOIN ready_items i
+                  ON i.media_id = e.series_id
+                 AND i.media_type = 'series'
+                WHERE e.season >= 1
+                  AND e.episode >= 1
+                  AND (e.next_retry_at IS NULL OR e.next_retry_at <= :now)
+                  AND (e.last_success_at IS NULL OR e.last_success_at <= :success_cutoff)
+                  AND (e.status != 'dead' OR e.consecutive_failures < :max_retries)
+            ),
+            ready_episodes AS (
+                SELECT
+                    CASE
+                        WHEN parent_ready_at >= episode_ready_at
+                        THEN parent_ready_at
+                        ELSE episode_ready_at
+                    END AS ready_at
+                FROM episode_candidates
             ),
             episode_snapshot AS (
                 SELECT
                     COUNT(*) AS episode_count,
-                    MIN(background_scraper_episodes.created_at) AS oldest_episode_ts
-                FROM background_scraper_episodes
-                JOIN background_scraper_items
-                  ON background_scraper_items.media_id = background_scraper_episodes.series_id
-                 AND background_scraper_items.media_type = 'series'
-                WHERE background_scraper_episodes.season >= 1
-                  AND background_scraper_episodes.episode >= 1
-                  AND (
-                        background_scraper_episodes.next_retry_at IS NULL
-                        OR background_scraper_episodes.next_retry_at <= :now
-                      )
-                  AND (
-                        background_scraper_episodes.last_success_at IS NULL
-                        OR background_scraper_episodes.last_success_at <= :success_cutoff
-                      )
-                  AND (
-                        background_scraper_episodes.status != 'dead'
-                        OR background_scraper_episodes.consecutive_failures < :max_retries
-                      )
-                  AND (
-                        background_scraper_items.next_retry_at IS NULL
-                        OR background_scraper_items.next_retry_at <= :now
-                      )
-                  AND (
-                        background_scraper_items.last_success_at IS NULL
-                        OR background_scraper_items.last_success_at <= :success_cutoff
-                      )
-                  AND (
-                        background_scraper_items.status != 'dead'
-                        OR background_scraper_items.consecutive_failures < :max_retries
-                      )
+                    MIN(ready_at) AS oldest_episode_ts
+                FROM ready_episodes
             )
             SELECT item_snapshot.*, episode_snapshot.*
             FROM item_snapshot

--- a/comet/templates/admin_dashboard.html
+++ b/comet/templates/admin_dashboard.html
@@ -1466,25 +1466,27 @@
 
                     <div class="bg-scraper-stats-grid">
                       <div class="bg-mini-stat">
-                        <div class="bg-mini-stat-label">Queue Movies</div>
+                        <div class="bg-mini-stat-label">Eligible Movies</div>
                         <div class="bg-mini-stat-value" id="bg-queue-movies">
                           0
                         </div>
                       </div>
                       <div class="bg-mini-stat">
-                        <div class="bg-mini-stat-label">Queue Series</div>
+                        <div class="bg-mini-stat-label">Eligible Series</div>
                         <div class="bg-mini-stat-value" id="bg-queue-series">
                           0
                         </div>
                       </div>
                       <div class="bg-mini-stat">
-                        <div class="bg-mini-stat-label">Queue Episodes</div>
+                        <div class="bg-mini-stat-label">Eligible Episodes</div>
                         <div class="bg-mini-stat-value" id="bg-queue-episodes">
                           0
                         </div>
                       </div>
                       <div class="bg-mini-stat">
-                        <div class="bg-mini-stat-label">Oldest Queue Age</div>
+                        <div class="bg-mini-stat-label">
+                          Oldest Eligible Age
+                        </div>
                         <div
                           class="bg-mini-stat-value"
                           id="bg-queue-oldest-age"

--- a/tests/test_background_worker.py
+++ b/tests/test_background_worker.py
@@ -12,6 +12,40 @@ from comet.background_scraper.worker import (
     _serialize_run_row,
 )
 from comet.core.db_router import ReplicaAwareDatabase
+from comet.core.models import settings
+
+
+async def _create_queue_database(path: Path) -> ReplicaAwareDatabase:
+    database = ReplicaAwareDatabase(Database(f"sqlite:///{path}"))
+    await database.connect()
+    await database.execute(
+        """
+        CREATE TABLE background_scraper_items (
+            media_id TEXT PRIMARY KEY,
+            media_type TEXT NOT NULL,
+            next_retry_at REAL,
+            last_success_at REAL,
+            status TEXT NOT NULL,
+            consecutive_failures INTEGER NOT NULL,
+            created_at REAL
+        )
+        """
+    )
+    await database.execute(
+        """
+        CREATE TABLE background_scraper_episodes (
+            series_id TEXT NOT NULL,
+            season INTEGER NOT NULL,
+            episode INTEGER NOT NULL,
+            next_retry_at REAL,
+            last_success_at REAL,
+            status TEXT NOT NULL,
+            consecutive_failures INTEGER NOT NULL,
+            created_at REAL
+        )
+        """
+    )
+    return database
 
 
 class BackgroundWorkerLifecycleTests(unittest.IsolatedAsyncioTestCase):
@@ -85,37 +119,8 @@ class BackgroundWorkerLifecycleTests(unittest.IsolatedAsyncioTestCase):
 class BackgroundWorkerQueryTests(unittest.IsolatedAsyncioTestCase):
     async def test_queue_snapshot_query_executes_against_sqlite(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            primary = Database(f"sqlite:///{Path(temp_dir) / 'queue.db'}")
-            database = ReplicaAwareDatabase(primary)
-            await database.connect()
+            database = await _create_queue_database(Path(temp_dir) / "queue.db")
             try:
-                await database.execute(
-                    """
-                    CREATE TABLE background_scraper_items (
-                        media_id TEXT PRIMARY KEY,
-                        media_type TEXT NOT NULL,
-                        next_retry_at REAL,
-                        last_success_at REAL,
-                        status TEXT NOT NULL,
-                        consecutive_failures INTEGER NOT NULL,
-                        created_at REAL
-                    )
-                    """
-                )
-                await database.execute(
-                    """
-                    CREATE TABLE background_scraper_episodes (
-                        series_id TEXT NOT NULL,
-                        season INTEGER NOT NULL,
-                        episode INTEGER NOT NULL,
-                        next_retry_at REAL,
-                        last_success_at REAL,
-                        status TEXT NOT NULL,
-                        consecutive_failures INTEGER NOT NULL,
-                        created_at REAL
-                    )
-                    """
-                )
                 await database.execute_many(
                     """
                     INSERT INTO background_scraper_items
@@ -151,7 +156,88 @@ class BackgroundWorkerQueryTests(unittest.IsolatedAsyncioTestCase):
                 await database.disconnect()
 
         self.assertEqual(snapshot["total"], 3)
-        self.assertEqual(snapshot["oldest_age_s"], 20.0)
+        self.assertEqual(snapshot["oldest_age_s"], 15.0)
+
+    async def test_queue_age_starts_when_success_becomes_refresh_eligible(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database = await _create_queue_database(Path(temp_dir) / "queue.db")
+            try:
+                await database.execute(
+                    """
+                    INSERT INTO background_scraper_items
+                    (media_id, media_type, next_retry_at, last_success_at, status,
+                     consecutive_failures, created_at)
+                    VALUES ('movie', 'movie', 97.0, 89.0, 'success', 0, 1.0)
+                    """
+                )
+
+                with (
+                    patch.object(settings, "BACKGROUND_SCRAPER_SUCCESS_TTL", 10),
+                    patch("comet.background_scraper.worker.database", database),
+                ):
+                    snapshot = await BackgroundScraperWorker()._fetch_queue_snapshot(
+                        now=100.0
+                    )
+            finally:
+                await database.disconnect()
+
+        self.assertEqual(snapshot["movies"], 1)
+        self.assertEqual(snapshot["oldest_age_s"], 1.0)
+
+    async def test_queue_age_starts_when_retry_becomes_eligible(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database = await _create_queue_database(Path(temp_dir) / "queue.db")
+            try:
+                await database.execute(
+                    """
+                    INSERT INTO background_scraper_items
+                    (media_id, media_type, next_retry_at, last_success_at, status,
+                     consecutive_failures, created_at)
+                    VALUES ('movie', 'movie', 98.0, NULL, 'failed', 1, 1.0)
+                    """
+                )
+
+                with patch("comet.background_scraper.worker.database", database):
+                    snapshot = await BackgroundScraperWorker()._fetch_queue_snapshot(
+                        now=100.0
+                    )
+            finally:
+                await database.disconnect()
+
+        self.assertEqual(snapshot["movies"], 1)
+        self.assertEqual(snapshot["oldest_age_s"], 2.0)
+
+    async def test_episode_queue_age_waits_for_parent_series(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database = await _create_queue_database(Path(temp_dir) / "queue.db")
+            try:
+                await database.execute(
+                    """
+                    INSERT INTO background_scraper_items
+                    (media_id, media_type, next_retry_at, last_success_at, status,
+                     consecutive_failures, created_at)
+                    VALUES ('series', 'series', 99.0, NULL, 'deferred', 0, 1.0)
+                    """
+                )
+                await database.execute(
+                    """
+                    INSERT INTO background_scraper_episodes
+                    (series_id, season, episode, next_retry_at, last_success_at,
+                     status, consecutive_failures, created_at)
+                    VALUES ('series', 1, 1, 90.0, NULL, 'failed', 1, 1.0)
+                    """
+                )
+
+                with patch("comet.background_scraper.worker.database", database):
+                    snapshot = await BackgroundScraperWorker()._fetch_queue_snapshot(
+                        now=100.0
+                    )
+            finally:
+                await database.disconnect()
+
+        self.assertEqual(snapshot["series"], 1)
+        self.assertEqual(snapshot["episodes"], 1)
+        self.assertEqual(snapshot["oldest_age_s"], 1.0)
 
     async def test_queue_snapshot_uses_one_primary_database_snapshot(self):
         worker = BackgroundScraperWorker()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background scraper queue age calculations to reflect when work becomes eligible, including refresh, retry, and series-dependent episode eligibility.
  * Updated queue health messaging to clarify that alerts concern eligible work waiting beyond the configured threshold.

* **UI**
  * Renamed Background Scraper dashboard metrics to “Eligible” entries and “Oldest Eligible Age” for clearer reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->