### PR TITLE
feat(background-scraper): add graceful stop after current run

### DIFF
--- a/comet/api/endpoints/admin.py
+++ b/comet/api/endpoints/admin.py
@@ -559,6 +559,57 @@ async def admin_background_scraper_stop(
 
 
 @router.post(
+    "/admin/api/background-scraper/drain",
+    tags=["Admin"],
+    summary="Stop Background Scraper After Current Run",
+    description=(
+        "Lets the active background scrape run finish, then stops the orchestrator "
+        "before another run starts. Stops immediately when no run is active."
+    ),
+)
+async def admin_background_scraper_drain(
+    admin_session: str = Cookie(None, description="Admin session token"),
+):
+    require_admin_auth(admin_session)
+    was_running = background_scraper.is_running
+    scheduled = await background_scraper.drain()
+    if scheduled:
+        state = "scheduled"
+        message = "Background scraper will stop after the current run"
+    elif was_running:
+        state = "stopped"
+        message = "Background scraper stopped; no run was active"
+    else:
+        state = "stopped"
+        message = "Background scraper is already stopped"
+    return JSONResponse({"success": True, "state": state, "message": message})
+
+
+@router.delete(
+    "/admin/api/background-scraper/drain",
+    tags=["Admin"],
+    summary="Cancel Scheduled Background Scraper Stop",
+    description="Cancels a pending stop-after-current-run request.",
+)
+async def admin_background_scraper_cancel_drain(
+    admin_session: str = Cookie(None, description="Admin session token"),
+):
+    require_admin_auth(admin_session)
+    cancelled = background_scraper.cancel_drain()
+    return JSONResponse(
+        {
+            "success": True,
+            "state": "running" if cancelled else "unchanged",
+            "message": (
+                "Scheduled background scraper stop cancelled"
+                if cancelled
+                else "No scheduled background scraper stop"
+            ),
+        }
+    )
+
+
+@router.post(
     "/admin/api/background-scraper/pause",
     tags=["Admin"],
     summary="Pause Background Scraper",

--- a/comet/api/endpoints/admin.py
+++ b/comet/api/endpoints/admin.py
@@ -571,17 +571,22 @@ async def admin_background_scraper_drain(
     admin_session: str = Cookie(None, description="Admin session token"),
 ):
     require_admin_auth(admin_session)
-    was_running = background_scraper.is_running
+    if not background_scraper.is_running:
+        return JSONResponse(
+            {
+                "success": True,
+                "state": "stopped",
+                "message": "Background scraper is already stopped",
+            }
+        )
+
     scheduled = await background_scraper.drain()
     if scheduled:
         state = "scheduled"
         message = "Background scraper will stop after the current run"
-    elif was_running:
-        state = "stopped"
-        message = "Background scraper stopped; no run was active"
     else:
         state = "stopped"
-        message = "Background scraper is already stopped"
+        message = "Background scraper stopped; no run was active"
     return JSONResponse({"success": True, "state": state, "message": message})
 
 

--- a/comet/background_scraper/worker.py
+++ b/comet/background_scraper/worker.py
@@ -834,7 +834,10 @@ class BackgroundScraperWorker:
                     await asyncio.sleep(next_cycle_delay)
         finally:
             self.is_running = False
+            self.is_paused = False
             self._drain_requested = False
+            self.pause_event.set()
+            self._reset_discovery_hysteresis()
 
     async def _run_scraping_cycle(self):
         run_id = str(uuid.uuid4())

--- a/comet/background_scraper/worker.py
+++ b/comet/background_scraper/worker.py
@@ -172,6 +172,7 @@ class BackgroundScraperWorker:
         self.metadata_scraper = None
         self.task: asyncio.Task | None = None
         self._active_scrape_task = None
+        self._drain_requested = False
         self._last_discovery_limit_normalization = None
         self._reset_discovery_hysteresis()
 
@@ -557,6 +558,7 @@ class BackgroundScraperWorker:
             logger.log("BACKGROUND_SCRAPER", "Background scraper is already running")
             return
 
+        self._drain_requested = False
         logger.log("BACKGROUND_SCRAPER", "Starting background scraper orchestrator")
         await self._run_continuous()
 
@@ -564,6 +566,7 @@ class BackgroundScraperWorker:
         logger.log("BACKGROUND_SCRAPER", "Stopping background scraper orchestrator")
         self.is_running = False
         self.is_paused = False
+        self._drain_requested = False
         self.pause_event.set()
 
         await self._cancel_task(self._active_scrape_task)
@@ -583,6 +586,31 @@ class BackgroundScraperWorker:
                 logger.error(f"Background scraper task stopped with error: {e}")
         self.task = None
         self._reset_discovery_hysteresis()
+
+    async def drain(self) -> bool:
+        """Stop after the active cycle, or immediately when no cycle is active."""
+        if not self.is_running:
+            return False
+
+        if self.current_run_id is None:
+            await self.stop()
+            return False
+
+        if not self._drain_requested:
+            self._drain_requested = True
+            logger.log(
+                "BACKGROUND_SCRAPER",
+                f"Run {self.current_run_id}: stop scheduled after completion",
+            )
+        return True
+
+    def cancel_drain(self) -> bool:
+        if not self.is_running or not self._drain_requested:
+            return False
+
+        self._drain_requested = False
+        logger.log("BACKGROUND_SCRAPER", "Scheduled stop cancelled")
+        return True
 
     async def pause(self):
         if not self.is_running:
@@ -694,6 +722,7 @@ class BackgroundScraperWorker:
         return {
             "running": self.is_running,
             "paused": self.is_paused,
+            "draining": self._drain_requested,
             "current_run_id": self.current_run_id,
             "last_error": self.last_error,
             "stats": {
@@ -737,6 +766,12 @@ class BackgroundScraperWorker:
             },
             "health": health,
             "actions": {
+                "can_drain": (
+                    self.is_running
+                    and self.current_run_id is not None
+                    and not self._drain_requested
+                ),
+                "can_cancel_drain": self.is_running and self._drain_requested,
                 "can_requeue_dead": True,
             },
             "latest_run": _serialize_run_row(latest_run) if latest_run else None,
@@ -760,32 +795,46 @@ class BackgroundScraperWorker:
         self.is_running = True
         interval_seconds = settings.BACKGROUND_SCRAPER_INTERVAL
 
-        while self.is_running:
-            try:
-                lock = DistributedLock(LOCK_KEY, timeout=LOCK_TTL)
-                if await lock.acquire(wait_timeout=None):
-                    try:
-                        scrape_task = asyncio.create_task(self._run_scraping_cycle())
-                        self._active_scrape_task = scrape_task
-                        await lock.run(scrape_task)
-                    finally:
-                        await lock.release()
-                        self._active_scrape_task = None
-                else:
+        try:
+            while self.is_running:
+                next_cycle_delay = interval_seconds
+                try:
+                    lock = DistributedLock(LOCK_KEY, timeout=LOCK_TTL)
+                    if await lock.acquire(wait_timeout=None):
+                        try:
+                            scrape_task = asyncio.create_task(
+                                self._run_scraping_cycle()
+                            )
+                            self._active_scrape_task = scrape_task
+                            await lock.run(scrape_task)
+                        finally:
+                            await lock.release()
+                            self._active_scrape_task = None
+                    else:
+                        logger.log(
+                            "BACKGROUND_SCRAPER",
+                            "Another instance is running background scraping. Skipping.",
+                        )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    self.last_error = str(e)
+                    next_cycle_delay = 300
+                    logger.error(f"Error in background scraper loop: {e}")
+
+                if self._drain_requested:
                     logger.log(
                         "BACKGROUND_SCRAPER",
-                        "Another instance is running background scraping. Skipping.",
+                        "Scheduled stop completed; no new cycle will be started",
                     )
+                    self._drain_requested = False
+                    break
 
                 if self.is_running:
-                    await asyncio.sleep(interval_seconds)
-            except asyncio.CancelledError:
-                self.is_running = False
-                raise
-            except Exception as e:
-                self.last_error = str(e)
-                logger.error(f"Error in background scraper loop: {e}")
-                await asyncio.sleep(300)
+                    await asyncio.sleep(next_cycle_delay)
+        finally:
+            self.is_running = False
+            self._drain_requested = False
 
     async def _run_scraping_cycle(self):
         run_id = str(uuid.uuid4())

--- a/comet/templates/admin_dashboard.html
+++ b/comet/templates/admin_dashboard.html
@@ -1415,7 +1415,21 @@
                           onclick="stopBackgroundScraper()"
                         >
                           <sl-icon slot="prefix" name="stop-fill"></sl-icon>
-                          Stop
+                          Stop Now
+                        </sl-button>
+                        <sl-button
+                          id="bg-action-drain"
+                          size="small"
+                          variant="warning"
+                          onclick="toggleBackgroundScraperDrain()"
+                          title="Finish the current run, then stop before the next one"
+                        >
+                          <sl-icon
+                            id="bg-action-drain-icon"
+                            slot="prefix"
+                            name="hourglass-split"
+                          ></sl-icon>
+                          <span id="bg-action-drain-label">Stop After Run</span>
                         </sl-button>
                         <sl-button
                           id="bg-action-requeue-dead"
@@ -3801,6 +3815,18 @@
         );
       }
 
+      async function toggleBackgroundScraperDrain() {
+        const button = document.getElementById("bg-action-drain");
+        const cancelling = button?.dataset.draining === "true";
+        await triggerBackgroundScraperAction(
+          "drain",
+          cancelling
+            ? "Scheduled stop cancelled"
+            : "Background scraper will stop after the current run",
+          cancelling ? "DELETE" : "POST",
+        );
+      }
+
       async function pauseBackgroundScraper() {
         await triggerBackgroundScraperAction(
           "pause",
@@ -3842,11 +3868,15 @@
         }
       }
 
-      async function triggerBackgroundScraperAction(action, successMessage) {
+      async function triggerBackgroundScraperAction(
+        action,
+        successMessage,
+        method = "POST",
+      ) {
         try {
           const response = await fetch(
             `/admin/api/background-scraper/${action}`,
-            { method: "POST" },
+            { method },
           );
           const data = await response.json().catch(() => ({}));
 
@@ -3854,7 +3884,7 @@
             throw new Error(data.message || data.detail || "Request failed");
           }
 
-          showToast(successMessage, "success");
+          showToast(data.message || successMessage, "success");
           await loadBackgroundScraperData();
         } catch (error) {
           console.error(`Background scraper ${action} failed:`, error);
@@ -3870,6 +3900,7 @@
         const dead = status.dead || {};
         const slo = status.slo || {};
         const health = status.health || {};
+        const actions = status.actions || {};
         const stats = status.stats || {};
         const latestRun = status.latest_run || {};
 
@@ -3914,6 +3945,7 @@
         ).toLocaleString();
         const orchestratorRunning = Boolean(status.running);
         const cycleRunning = Boolean(status.current_run_id);
+        const draining = Boolean(status.draining);
         const latestRunStatus = String(latestRun.status || "").toLowerCase();
         const latestRunFinishedAt = Number(latestRun.finished_at || 0);
         const latestRunStartedAt = Number(latestRun.started_at || 0);
@@ -3926,12 +3958,20 @@
         const pauseBtn = document.getElementById("bg-action-pause");
         const resumeBtn = document.getElementById("bg-action-resume");
         const stopBtn = document.getElementById("bg-action-stop");
+        const drainBtn = document.getElementById("bg-action-drain");
+        const drainIcon = document.getElementById("bg-action-drain-icon");
+        const drainLabel = document.getElementById("bg-action-drain-label");
         const requeueDeadBtn = document.getElementById(
           "bg-action-requeue-dead",
         );
         const healthBadge = document.getElementById("bg-scraper-health-badge");
 
-        if (orchestratorRunning && status.paused) {
+        if (draining) {
+          badge.variant = "warning";
+          badge.textContent = status.paused
+            ? "Stop Pending · Paused"
+            : "Stopping After Run";
+        } else if (orchestratorRunning && status.paused) {
           badge.variant = "warning";
           badge.textContent = "Paused";
         } else if (cycleRunning) {
@@ -3961,11 +4001,30 @@
         if (startBtn) startBtn.disabled = orchestratorRunning;
         if (pauseBtn)
           pauseBtn.disabled =
-            !orchestratorRunning || Boolean(status.paused);
+            !orchestratorRunning || Boolean(status.paused) || draining;
         if (resumeBtn)
           resumeBtn.disabled =
             !orchestratorRunning || !Boolean(status.paused);
         if (stopBtn) stopBtn.disabled = !orchestratorRunning;
+        if (drainBtn) {
+          drainBtn.dataset.draining = draining ? "true" : "false";
+          drainBtn.disabled = !(
+            Boolean(actions.can_drain) ||
+            Boolean(actions.can_cancel_drain)
+          );
+          drainBtn.variant = draining ? "neutral" : "warning";
+          drainBtn.title = draining
+            ? "Cancel the scheduled stop and keep running future cycles"
+            : "Finish the current run, then stop before the next one";
+        }
+        if (drainIcon) {
+          drainIcon.name = draining ? "x-circle" : "hourglass-split";
+        }
+        if (drainLabel) {
+          drainLabel.textContent = draining
+            ? "Keep Running"
+            : "Stop After Run";
+        }
         if (requeueDeadBtn)
           requeueDeadBtn.disabled = !(
             Number(dead.movies || 0) > 0 ||
@@ -3975,6 +4034,9 @@
 
         if (!orchestratorRunning) {
           backgroundScraperNextCycleState = "stopped";
+          backgroundScraperNextCycleTargetTs = null;
+        } else if (draining) {
+          backgroundScraperNextCycleState = "draining";
           backgroundScraperNextCycleTargetTs = null;
         } else if (Boolean(status.paused)) {
           backgroundScraperNextCycleState = "paused";

--- a/docs/advanced/04-scrapers-background-and-dmm.md
+++ b/docs/advanced/04-scrapers-background-and-dmm.md
@@ -75,7 +75,8 @@ Refresh interval is `INDEXER_MANAGER_UPDATE_INTERVAL`.
 - distributed lock (`background_scraper_lock`)
 - queue watermark/hard-cap policy
 - run budgeting (`BACKGROUND_SCRAPER_RUN_TIME_BUDGET`)
-- pause/resume/start/stop controls
+- pause/resume/start/immediate-stop controls
+- a cancellable drain mode that finishes the active run before stopping
 - dead-item requeue API
 - run history and SLO-style status output
 

--- a/docs/beginner/03-admin-dashboard.md
+++ b/docs/beginner/03-admin-dashboard.md
@@ -32,7 +32,10 @@ Session behavior:
 
 4. **Background Scraper**
 - View status, run history, queue and SLO info.
-- Start/stop/pause/resume/requeue-dead from the dashboard.
+- Start, pause, resume, or stop immediately.
+- **Stop After Run** finishes the current scrape before stopping; while it is
+  pending, **Keep Running** cancels the scheduled stop.
+- Requeue dead items and episodes.
 
 5. **CometNet**
 - Visible for CometNet operations and pool management APIs.

--- a/tests/test_admin_metrics.py
+++ b/tests/test_admin_metrics.py
@@ -1,5 +1,9 @@
 import unittest
+from unittest.mock import AsyncMock, patch
 
+import orjson
+
+from comet.api.endpoints import admin
 from comet.api.endpoints.admin import _decode_cached_metrics
 
 
@@ -11,3 +15,36 @@ class AdminMetricsTests(unittest.TestCase):
         )
         self.assertIsNone(_decode_cached_metrics("not-json"))
         self.assertIsNone(_decode_cached_metrics("[]"))
+
+
+class AdminBackgroundScraperTests(unittest.IsolatedAsyncioTestCase):
+    async def test_drain_endpoint_reports_scheduled_stop(self):
+        with (
+            patch.object(admin, "require_admin_auth"),
+            patch.object(admin.background_scraper, "is_running", True),
+            patch.object(
+                admin.background_scraper,
+                "drain",
+                new=AsyncMock(return_value=True),
+            ) as drain,
+        ):
+            response = await admin.admin_background_scraper_drain()
+
+        drain.assert_awaited_once_with()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(orjson.loads(response.body)["state"], "scheduled")
+
+    async def test_cancel_drain_endpoint_is_idempotent(self):
+        with (
+            patch.object(admin, "require_admin_auth"),
+            patch.object(
+                admin.background_scraper,
+                "cancel_drain",
+                return_value=False,
+            ) as cancel_drain,
+        ):
+            response = await admin.admin_background_scraper_cancel_drain()
+
+        cancel_drain.assert_called_once_with()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(orjson.loads(response.body)["state"], "unchanged")

--- a/tests/test_admin_metrics.py
+++ b/tests/test_admin_metrics.py
@@ -34,6 +34,38 @@ class AdminBackgroundScraperTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(orjson.loads(response.body)["state"], "scheduled")
 
+    async def test_drain_endpoint_stops_when_no_run_is_active(self):
+        with (
+            patch.object(admin, "require_admin_auth"),
+            patch.object(admin.background_scraper, "is_running", True),
+            patch.object(
+                admin.background_scraper,
+                "drain",
+                new=AsyncMock(return_value=False),
+            ) as drain,
+        ):
+            response = await admin.admin_background_scraper_drain()
+
+        drain.assert_awaited_once_with()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(orjson.loads(response.body)["state"], "stopped")
+
+    async def test_drain_endpoint_is_idempotent_when_already_stopped(self):
+        with (
+            patch.object(admin, "require_admin_auth"),
+            patch.object(admin.background_scraper, "is_running", False),
+            patch.object(
+                admin.background_scraper,
+                "drain",
+                new=AsyncMock(),
+            ) as drain,
+        ):
+            response = await admin.admin_background_scraper_drain()
+
+        drain.assert_not_awaited()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(orjson.loads(response.body)["state"], "stopped")
+
     async def test_cancel_drain_endpoint_is_idempotent(self):
         with (
             patch.object(admin, "require_admin_auth"),

--- a/tests/test_background_worker.py
+++ b/tests/test_background_worker.py
@@ -48,7 +48,96 @@ async def _create_queue_database(path: Path) -> ReplicaAwareDatabase:
     return database
 
 
+class _PassthroughLock:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def acquire(self, **_kwargs):
+        return True
+
+    async def run(self, task):
+        await task
+
+    async def release(self):
+        pass
+
+
 class BackgroundWorkerLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_drain_finishes_active_cycle_without_starting_another(self):
+        worker = BackgroundScraperWorker()
+        cycle_started = asyncio.Event()
+        finish_cycle = asyncio.Event()
+        cycle_count = 0
+
+        async def run_cycle():
+            nonlocal cycle_count
+            cycle_count += 1
+            worker.current_run_id = "active-run"
+            cycle_started.set()
+            await finish_cycle.wait()
+            worker.current_run_id = None
+
+        worker._run_scraping_cycle = run_cycle
+
+        with patch("comet.background_scraper.worker.DistributedLock", _PassthroughLock):
+            task = asyncio.create_task(worker._run_continuous())
+            await cycle_started.wait()
+
+            self.assertTrue(await worker.drain())
+            self.assertTrue(await worker.drain())
+            self.assertTrue(worker.is_running)
+            self.assertTrue(worker._drain_requested)
+
+            finish_cycle.set()
+            await asyncio.wait_for(task, timeout=1)
+
+        self.assertEqual(cycle_count, 1)
+        self.assertFalse(worker.is_running)
+        self.assertFalse(worker._drain_requested)
+
+    async def test_drain_stops_immediately_when_between_cycles(self):
+        worker = BackgroundScraperWorker()
+        worker.is_running = True
+        worker.stop = AsyncMock()
+
+        self.assertFalse(await worker.drain())
+
+        worker.stop.assert_awaited_once_with()
+
+    async def test_scheduled_stop_can_be_cancelled(self):
+        worker = BackgroundScraperWorker()
+        worker.is_running = True
+        worker.current_run_id = "active-run"
+
+        self.assertTrue(await worker.drain())
+        self.assertTrue(worker.cancel_drain())
+        self.assertFalse(worker._drain_requested)
+        self.assertFalse(worker.cancel_drain())
+
+    async def test_drain_is_honored_when_active_cycle_fails(self):
+        worker = BackgroundScraperWorker()
+        cycle_started = asyncio.Event()
+        fail_cycle = asyncio.Event()
+
+        async def run_cycle():
+            worker.current_run_id = "active-run"
+            cycle_started.set()
+            await fail_cycle.wait()
+            worker.current_run_id = None
+            raise RuntimeError("cycle failed")
+
+        worker._run_scraping_cycle = run_cycle
+
+        with patch("comet.background_scraper.worker.DistributedLock", _PassthroughLock):
+            task = asyncio.create_task(worker._run_continuous())
+            await cycle_started.wait()
+            self.assertTrue(await worker.drain())
+            fail_cycle.set()
+            await asyncio.wait_for(task, timeout=1)
+
+        self.assertEqual(worker.last_error, "cycle failed")
+        self.assertFalse(worker.is_running)
+
     async def test_run_insert_failure_clears_published_runtime_state(self):
         worker = BackgroundScraperWorker()
         worker._insert_run_row = AsyncMock(side_effect=RuntimeError("insert failed"))

--- a/tests/test_background_worker.py
+++ b/tests/test_background_worker.py
@@ -87,13 +87,19 @@ class BackgroundWorkerLifecycleTests(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(await worker.drain())
             self.assertTrue(worker.is_running)
             self.assertTrue(worker._drain_requested)
+            worker.is_paused = True
+            worker.pause_event.clear()
+            worker._discovery_paused_for_backlog = True
 
             finish_cycle.set()
             await asyncio.wait_for(task, timeout=1)
 
         self.assertEqual(cycle_count, 1)
         self.assertFalse(worker.is_running)
+        self.assertFalse(worker.is_paused)
         self.assertFalse(worker._drain_requested)
+        self.assertTrue(worker.pause_event.is_set())
+        self.assertFalse(worker._discovery_paused_for_backlog)
 
     async def test_drain_stops_immediately_when_between_cycles(self):
         worker = BackgroundScraperWorker()

--- a/tests/test_templates_assets.py
+++ b/tests/test_templates_assets.py
@@ -60,6 +60,12 @@ class DashboardTemplateTests(unittest.TestCase):
         self.assertNotIn("StaticFiles", app_source)
         self.assertNotIn('app.mount("/static"', app_source)
 
+    def test_background_scraper_drain_control_is_reversible(self):
+        self.assertIn('id="bg-action-drain"', self.dashboard)
+        self.assertIn("function toggleBackgroundScraperDrain()", self.dashboard)
+        self.assertIn('cancelling ? "DELETE" : "POST"', self.dashboard)
+        self.assertIn("Boolean(actions.can_cancel_drain)", self.dashboard)
+
 
 class ConfigurationTemplateTests(unittest.TestCase):
     @classmethod


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Stop After Run” (drain) for the background scraper, plus an option to cancel the scheduled stop.
  * Introduced admin controls/API endpoints to schedule draining and cancel it, with clear returned states.
  * Updated the admin dashboard UI with “Stop Now”, reversible drain controls, and improved draining/pending stop status indicators.

* **Documentation**
  * Refreshed background scraper/admin dashboard guidance to match the new drain behavior.

* **Tests**
  * Added endpoint and worker lifecycle test coverage for draining, cancellation, idempotency, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->