### PR TITLE
feat(torznab): add native Torznab search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 # Features
 - **CometNet**: Decentralized P2P network for automatic torrent metadata sharing ([documentation](docs/cometnet/README.md))
 - **Kodi Support**: Dedicated official add-on with automatic updates ([documentation](kodi/README.md))
+- **Torznab Support**: Official Prowlarr, Sonarr, Radarr, and Jackett integration ([documentation](docs/integrations/torznab.md))
 - Proxy Debrid Streams to allow simultaneous use on multiple IPs!
 - IP-Based Max Connection Limit
 - Administration Dashboard with Bandwidth Manager, Metrics and more...

--- a/comet/api/app.py
+++ b/comet/api/app.py
@@ -20,6 +20,7 @@ from comet.api.endpoints import (
     manifest,
     playback,
     prometheus,
+    torznab,
 )
 from comet.api.endpoints import stream as streams_router
 from comet.background_scraper.worker import background_scraper
@@ -267,6 +268,7 @@ stremio_routers = (
     playback.router,
     debrid_sync.router,
     streams_router.streams,
+    torznab.router,
     chilllink.router,
 )
 

--- a/comet/api/endpoints/stream.py
+++ b/comet/api/endpoints/stream.py
@@ -1,30 +1,13 @@
-import asyncio
 from collections import defaultdict
 from urllib.parse import quote
 
 from fastapi import APIRouter, BackgroundTasks, Request
 
 from comet.core.config_validation import config_check
-from comet.core.logger import logger
 from comet.core.models import settings
-from comet.core.scrape import ScrapeContext
-from comet.debrid.exceptions import DebridAuthError
 from comet.debrid.manager import get_debrid_extension
-from comet.metadata.episode_index import EpisodeIndexService
-from comet.metadata.filter import release_filter
-from comet.metadata.manager import MetadataScraper
 from comet.observability import metrics
-from comet.services.anime import anime_mapper
-from comet.services.cache_state import CacheStateManager, mark_scope_scraped
-from comet.services.debrid import DebridService
-from comet.services.debrid_account_scraper import (
-    ensure_account_snapshot_ready,
-    get_account_torrents_for_media,
-    ingest_account_torrents_to_public_cache,
-    schedule_account_snapshot_refresh,
-)
-from comet.services.lock import DistributedLock
-from comet.services.orchestration import TorrentManager
+from comet.services.media_search import MediaSearchStatus, search_media
 from comet.services.trackers import trackers
 from comet.utils.cache import (
     CachedJSONResponse,
@@ -39,9 +22,7 @@ from comet.utils.formatting import (
     get_formatted_components,
     get_formatted_components_plain,
 )
-from comet.utils.http_client import http_client_manager
 from comet.utils.network import get_client_ip
-from comet.utils.parsing import MediaScope, parse_media_id, resolve_media_scope
 
 streams = APIRouter()
 STREMIO_API_PREFIX = settings.STREMIO_API_PREFIX
@@ -163,31 +144,6 @@ def _encode_playback_scope(value: int | None) -> str:
     return str(value) if value is not None else "n"
 
 
-def _episode_matching_policy(
-    media_type: str,
-    media_only_id: str,
-    search_season: int | None,
-    search_episode: int | None,
-    *,
-    cached_only: bool,
-    has_debrid: bool,
-    enable_torrent: bool,
-) -> tuple[bool, bool]:
-    is_imdb_episode_request = (
-        media_type == "series"
-        and search_season is not None
-        and search_episode is not None
-        and media_only_id.startswith("tt")
-    )
-    allow_debrid_verified_season_packs = (
-        is_imdb_episode_request and cached_only and has_debrid and not enable_torrent
-    )
-    reject_unknown_episode_files = (
-        is_imdb_episode_request and not allow_debrid_verified_season_packs
-    )
-    return is_imdb_episode_request, reject_unknown_episode_files
-
-
 def _select_info_hashes_by_resolution(
     ranked_info_hashes,
     torrents: dict,
@@ -240,263 +196,6 @@ def _select_info_hashes_by_resolution(
     return selected_info_hashes
 
 
-def _merge_service_cache_status(target: dict, incoming: dict):
-    for info_hash, service_map in incoming.items():
-        cache_map = target.setdefault(info_hash, {})
-        for service, is_cached in service_map.items():
-            if is_cached:
-                cache_map[service] = True
-            elif service not in cache_map:
-                cache_map[service] = False
-
-
-async def _mark_scope_scraped_if_populated(media_id: str, torrents: dict) -> None:
-    if torrents:
-        await mark_scope_scraped(media_id)
-
-
-def _group_debrid_entries_by_service(debrid_entries: list) -> list[tuple[str, list]]:
-    service_entries = {}
-    seen_credentials = set()
-    for entry in debrid_entries:
-        service = entry["service"]
-        credential = (service, entry["apiKey"])
-        if credential in seen_credentials:
-            continue
-        seen_credentials.add(credential)
-        service_entries.setdefault(service, []).append(entry)
-    return list(service_entries.items())
-
-
-def _select_debrid_refresh_hashes(
-    current_hashes: set[str],
-    initial_hashes: set[str],
-    verified_cache_status: dict,
-    *,
-    had_cached_torrents: bool,
-    use_account_scrape: bool,
-) -> set[str]:
-    if not current_hashes:
-        return set()
-
-    verified_count = sum(
-        any(service_map.values())
-        for info_hash, service_map in verified_cache_status.items()
-        if info_hash in current_hashes
-    )
-    requires_full_refresh = (
-        (not had_cached_torrents and not use_account_scrape)
-        or verified_count == 0
-        or (verified_count / len(current_hashes)) < settings.DEBRID_CACHE_CHECK_RATIO
-    )
-    return current_hashes if requires_full_refresh else current_hashes - initial_hashes
-
-
-async def background_scrape(
-    torrent_manager: TorrentManager,
-    media_id: str,
-    debrid_entries: list,
-    ip: str,
-    session,
-):
-    scrape_lock = DistributedLock(media_id)
-    lock_acquired = await scrape_lock.acquire()
-
-    if not lock_acquired:
-        logger.log(
-            "SCRAPER",
-            f"🔒 Background scrape skipped for {media_id} - already in progress",
-        )
-        return
-
-    async def run_scrape():
-        await torrent_manager.scrape_torrents(ScrapeContext.BACKGROUND)
-
-        if debrid_entries and len(torrent_manager.torrents) > 0:
-            await get_and_cache_multi_service_availability(
-                session,
-                debrid_entries,
-                torrent_manager.torrents,
-                torrent_manager.media_id,
-                torrent_manager.media_only_id,
-                torrent_manager.search_season,
-                torrent_manager.search_episode,
-                torrent_manager.media_scope,
-                ip,
-                target_air_date=torrent_manager.target_air_date,
-            )
-
-    try:
-        await scrape_lock.run(run_scrape())
-        await _mark_scope_scraped_if_populated(media_id, torrent_manager.torrents)
-
-        logger.log(
-            "SCRAPER",
-            f"📥 Background scrape complete for {media_id}!",
-        )
-    except Exception as e:
-        logger.log("SCRAPER", f"❌ Background scrape failed for {media_id}: {e}")
-    finally:
-        await scrape_lock.release()
-
-
-async def check_multi_service_availability(
-    debrid_entries: list,
-    torrents: dict,
-    season: int | None,
-    episode: int | None,
-    media_scope: MediaScope,
-):
-    service_cache_status = defaultdict(dict)
-    info_hashes = list(torrents.keys())
-    if not info_hashes or not debrid_entries:
-        return service_cache_status
-
-    async def check_service(entry):
-        service = entry["service"]
-        api_key = entry["apiKey"]
-
-        debrid_instance = DebridService(service, api_key, "")
-        (
-            cached_hashes,
-            torrent_updates,
-        ) = await debrid_instance.check_existing_availability(
-            info_hashes, season, episode, media_scope, torrents
-        )
-
-        return service, cached_hashes, torrent_updates
-
-    service_groups = _group_debrid_entries_by_service(debrid_entries)
-
-    if service_groups:
-        results = await asyncio.gather(
-            *(check_service(entries[0]) for _, entries in service_groups),
-            return_exceptions=True,
-        )
-
-        enriched_hashes = set()
-        for result in results:
-            if isinstance(result, Exception):
-                logger.log("DEBRID", f"❌ Error checking availability: {result}")
-                continue
-            service, cached_hashes, torrent_updates = result
-            for info_hash, update in torrent_updates.items():
-                if info_hash in enriched_hashes:
-                    continue
-                torrent = torrents.get(info_hash)
-                if torrent is not None:
-                    torrent.update(update)
-                    enriched_hashes.add(info_hash)
-            for info_hash in cached_hashes:
-                service_cache_status[info_hash][service] = True
-
-    return service_cache_status
-
-
-async def get_and_cache_multi_service_availability(
-    session,
-    debrid_entries: list,
-    torrents: dict,
-    media_id: str,
-    media_only_id: str,
-    season: int | None,
-    episode: int | None,
-    media_scope: MediaScope,
-    ip: str,
-    target_air_date: str | None = None,
-    known_cache_status: dict | None = None,
-):
-    service_cache_status = defaultdict(dict)
-    errors = {}
-    info_hashes = list(torrents.keys())
-
-    if not info_hashes or not debrid_entries:
-        return service_cache_status, errors
-
-    seeders_map = {h: torrents[h]["seeders"] for h in info_hashes}
-    tracker_map = {h: torrents[h]["tracker"] for h in info_hashes}
-    sources_map = {h: torrents[h]["sources"] for h in info_hashes}
-
-    service_groups = _group_debrid_entries_by_service(debrid_entries)
-    known_cache_status = known_cache_status or {}
-
-    async def check_service(service, entries):
-        service_info_hashes = [
-            info_hash
-            for info_hash in info_hashes
-            if not known_cache_status.get(info_hash, {}).get(service, False)
-        ]
-        if not service_info_hashes:
-            return service, set(), {}, None
-
-        auth_error = None
-        for entry in entries:
-            try:
-                debrid_instance = DebridService(service, entry["apiKey"], ip)
-                (
-                    cached_hashes,
-                    torrent_updates,
-                ) = await debrid_instance.get_and_cache_availability(
-                    session,
-                    service_info_hashes,
-                    seeders_map,
-                    tracker_map,
-                    sources_map,
-                    torrents,
-                    media_id,
-                    media_only_id,
-                    season,
-                    episode,
-                    media_scope,
-                    target_air_date=target_air_date,
-                )
-                return service, cached_hashes, torrent_updates, None
-            except DebridAuthError as error:
-                if auth_error is None:
-                    auth_error = error
-            except Exception as error:
-                return service, None, None, error
-
-        return service, None, None, auth_error
-
-    if service_groups:
-        results = await asyncio.gather(
-            *(check_service(service, entries) for service, entries in service_groups),
-            return_exceptions=True,
-        )
-
-        enriched_hashes = set()
-        for result in results:
-            if isinstance(result, Exception):
-                logger.log("DEBRID", f"❌ Error checking availability: {result}")
-                continue
-
-            service, cache_map, torrent_updates, error = result
-            if error:
-                if isinstance(error, DebridAuthError):
-                    errors[service] = error
-                else:
-                    logger.log(
-                        "DEBRID",
-                        f"❌ Error checking availability on {service}: {error}",
-                    )
-                continue
-
-            for info_hash, update in torrent_updates.items():
-                if info_hash in enriched_hashes:
-                    continue
-                torrent = torrents.get(info_hash)
-                if torrent is not None:
-                    torrent.update(update)
-                    enriched_hashes.add(info_hash)
-
-            if cache_map:
-                for info_hash in cache_map:
-                    service_cache_status[info_hash][service] = True
-
-    return service_cache_status, errors
-
-
 @streams.get(
     "/stream/{media_type}/{media_id}.json",
     tags=["Stremio"],
@@ -544,8 +243,9 @@ async def stream(
     debrid_entries = config["_debridEntries"]
     enable_torrent = config["_enableTorrent"]
     deduplicate_streams = config["deduplicateStreams"]
-    scrape_debrid_account_torrents = config["scrapeDebridAccountTorrents"]
-    use_account_scrape = bool(debrid_entries and scrape_debrid_account_torrents)
+    use_account_scrape = bool(
+        debrid_entries and config["scrapeDebridAccountTorrents"]
+    )
     response_cache_policy = CachePolicies.no_cache() if use_account_scrape else None
     stream_cache_state = "unknown"
     stream_client = "kodi" if kodi else ("chilllink" if chilllink else "stremio")
@@ -566,9 +266,19 @@ async def stream(
             cache_policy=response_cache_policy,
         )
 
-    is_torrent_only = enable_torrent and not debrid_entries
+    search_result = await search_media(
+        media_type,
+        media_id,
+        config,
+        get_client_ip(request),
+        background_tasks.add_task,
+    )
+    stream_cache_state = search_result.cache_state
 
-    if settings.DISABLE_TORRENT_STREAMS and is_torrent_only:
+    if search_result.status is MediaSearchStatus.INVALID:
+        return _stream_response({"streams": []}, is_empty=True)
+
+    if search_result.status is MediaSearchStatus.DISABLED:
         placeholder_stream = {
             "name": settings.TORRENT_DISABLED_STREAM_NAME,
             "description": settings.TORRENT_DISABLED_STREAM_DESCRIPTION,
@@ -578,48 +288,30 @@ async def stream(
 
         return _stream_response({"streams": [placeholder_stream]})
 
-    session = await http_client_manager.get_session()
-    metadata_scraper = MetadataScraper(session)
-
-    try:
-        id, season, episode = parse_media_id(media_type, media_id)
-    except ValueError:
-        return _stream_response({"streams": []}, is_empty=True)
-    media_scope = resolve_media_scope(media_type, season, episode)
-
-    if settings.DIGITAL_RELEASE_FILTER:
-        is_released = await release_filter.check_is_released(
-            session, media_type, media_id, season, episode
-        )
-
-        if not is_released:
-            logger.log("FILTER", f"🚫 {media_id} is not released yet. Skipping.")
-            return _stream_response(
-                {
-                    "streams": [
-                        {
-                            "name": _stream_notice_name(
-                                kodi, "[🚫] Comet", "[BLOCKED] Comet"
-                            ),
-                            "description": "Content not digitally released yet.",
-                            "url": "https://comet.feels.legal",
-                        }
-                    ]
-                },
-                is_empty=True,
-            )
-
-    metadata, aliases = await metadata_scraper.fetch_metadata_and_aliases(
-        media_type, media_id, id, season, episode
-    )
-
-    if metadata is None:
-        logger.log("SCRAPER", f"❌ Failed to fetch metadata for {media_id}")
+    if search_result.status is MediaSearchStatus.UNRELEASED:
         return _stream_response(
             {
                 "streams": [
                     {
-                        "name": _stream_notice_name(kodi, "[⚠️] Comet", "[WARN] Comet"),
+                        "name": _stream_notice_name(
+                            kodi, "[🚫] Comet", "[BLOCKED] Comet"
+                        ),
+                        "description": "Content not digitally released yet.",
+                        "url": "https://comet.feels.legal",
+                    }
+                ]
+            },
+            is_empty=True,
+        )
+
+    if search_result.status is MediaSearchStatus.METADATA_UNAVAILABLE:
+        return _stream_response(
+            {
+                "streams": [
+                    {
+                        "name": _stream_notice_name(
+                            kodi, "[⚠️] Comet", "[WARN] Comet"
+                        ),
                         "description": "Unable to get metadata.",
                         "url": "https://comet.feels.legal",
                     }
@@ -628,142 +320,18 @@ async def stream(
             is_empty=True,
         )
 
-    title = metadata["title"]
-    year = metadata["year"]
-    year_end = metadata["year_end"]
-    season = metadata["season"]
-    episode = metadata["episode"]
-
-    log_title = f"({media_id}) {title}"
-    if media_type == "series" and episode is not None:
-        log_title += f" S{season:02d}E{episode:02d}"
-
-    logger.log("SCRAPER", f"🔍 Starting search for {log_title}")
-
-    media_only_id = id
-    ip = get_client_ip(request)
-
-    is_kitsu = media_id.startswith("kitsu:")
-    search_episode = episode
-    search_season = season
-
-    if is_kitsu:
-        kitsu_mapping = anime_mapper.get_kitsu_episode_mapping(id)
-        if kitsu_mapping:
-            from_episode = kitsu_mapping.get("from_episode")
-            from_season = kitsu_mapping.get("from_season")
-            if from_season is not None and from_season != season:
-                search_season = from_season
-            if episode is not None and from_episode is not None:
-                new_episode = from_episode + episode - 1
-                if new_episode != episode:
-                    search_episode = new_episode
-
-            if search_season != season or search_episode != episode:
-                if episode is not None and search_season is not None:
-                    logger.log(
-                        "SCRAPER",
-                        f"📺 Multi-part anime detected (kitsu:{id}): searching for S{search_season:02d}E{search_episode:02d} instead of S{season:02d}E{episode:02d}",
-                    )
-                elif search_season is not None and season is not None:
-                    logger.log(
-                        "SCRAPER",
-                        f"📺 Multi-part anime detected (kitsu:{id}): searching for S{search_season:02d} instead of S{season:02d}",
-                    )
-
-    cache_media_ids = [media_only_id]
-    if anime_mapper.is_loaded():
-        if is_kitsu:
-            imdb_id = await anime_mapper.get_imdb_from_kitsu(id)
-            if imdb_id:
-                cache_media_ids.append(imdb_id)
-        elif anime_mapper.is_anime_content(media_id, media_only_id):
-            kitsu_ids = anime_mapper.get_kitsu_ids_from_imdb(id)
-            if kitsu_ids:
-                cache_media_ids.extend(kitsu_ids)
-
-            # always include the base IMDb-Kitsu link if present
-            kitsu_id = await anime_mapper.get_kitsu_from_imdb(id)
-            if kitsu_id and kitsu_id not in cache_media_ids:
-                cache_media_ids.append(kitsu_id)
-
-    is_imdb_episode_request, reject_unknown_episode_files = _episode_matching_policy(
-        media_type,
-        media_only_id,
-        search_season,
-        search_episode,
-        cached_only=bool(config["cachedOnly"]),
-        has_debrid=bool(debrid_entries),
-        enable_torrent=enable_torrent,
-    )
-    target_air_date = None
-    if is_imdb_episode_request:
-        target_air_date = await EpisodeIndexService(session).get_target_air_date(
-            media_only_id,
-            search_season,
-            search_episode,
-        )
-        if target_air_date:
-            logger.log(
-                "SCRAPER",
-                f"📅 Episode target air date: {target_air_date} for {media_only_id} S{search_season:02d}E{search_episode:02d}",
-            )
-        else:
-            logger.log(
-                "SCRAPER",
-                f"📅 Episode target air date unavailable for {media_only_id} S{search_season:02d}E{search_episode:02d}",
-            )
-
-    remove_adult_content = settings.REMOVE_ADULT_CONTENT and config["removeTrash"]
-    torrent_manager = TorrentManager(
-        media_type,
-        media_id,
-        media_only_id,
-        title,
-        year,
-        year_end,
-        season,
-        episode,
-        aliases,
-        remove_adult_content,
-        is_kitsu=is_kitsu,
-        search_episode=search_episode,
-        search_season=search_season,
-        cache_media_ids=cache_media_ids,
-        target_air_date=target_air_date,
-        reject_unknown_episode_files=reject_unknown_episode_files,
-        media_scope=media_scope,
-    )
-
-    await torrent_manager.get_cached_torrents()
-    torrent_count = len(torrent_manager.torrents)
-    stream_cache_state = "hit" if torrent_count else "miss"
-    metrics.observe_torrent_cache(media_type, stream_cache_state, torrent_count)
-    initial_info_hashes = set(torrent_manager.torrents)
-    logger.log("SCRAPER", f"📦 Found cached torrents: {torrent_count}")
-    primary_cached = torrent_manager.primary_cached
-
-    cache_manager = CacheStateManager(media_id)
-    cache_result = await cache_manager.check_and_decide(torrent_count)
-    force_scrape_now = not primary_cached
-    lock_acquired = cache_result.lock_acquired
-
-    sort_mixed = is_torrent_only or config["sortCachedUncachedTogether"]
-    account_snapshot_ready = False
-    cached_results = []
-    non_cached_results = []
-
-    def _wait_response():
-        logger.log(
-            "SCRAPER",
-            f"🔄 Another instance is scraping {log_title}, returning early",
-        )
+    if search_result.status is MediaSearchStatus.BUSY:
         return _stream_response(
             {
                 "streams": [
                     {
-                        "name": _stream_notice_name(kodi, "[🔄] Comet", "[INFO] Comet"),
-                        "description": "Scraping in progress, please try again in a few seconds...",
+                        "name": _stream_notice_name(
+                            kodi, "[🔄] Comet", "[INFO] Comet"
+                        ),
+                        "description": (
+                            "Scraping in progress, please try again in a few "
+                            "seconds..."
+                        ),
                         "url": "https://comet.feels.legal",
                     }
                 ]
@@ -771,222 +339,28 @@ async def stream(
             is_empty=True,
         )
 
-    if force_scrape_now and not lock_acquired:
-        lock_acquired = await cache_manager.try_acquire_lock()
-
-    if force_scrape_now and not lock_acquired:
-        return _wait_response()
-
-    if cache_result.should_return_wait_message and not force_scrape_now:
-        return _wait_response()
-
-    if cache_result.should_scrape_background and not force_scrape_now:
-        logger.log(
-            "SCRAPER",
-            f"🔄 Starting background scrape for {log_title} (state={cache_result.state.value})",
-        )
-        background_tasks.add_task(
-            background_scrape,
-            torrent_manager,
-            media_id,
-            debrid_entries,
-            ip,
-            session,
-        )
-
-    if cache_result.should_scrape_now or force_scrape_now:
-        logger.log("SCRAPER", f"🔎 Starting new search for {log_title}")
-        try:
-            if use_account_scrape:
-                scrape_result, warmup_result = await asyncio.gather(
-                    torrent_manager.scrape_torrents(ScrapeContext.LIVE),
-                    ensure_account_snapshot_ready(session, debrid_entries, ip),
-                    return_exceptions=True,
-                )
-                if isinstance(scrape_result, Exception):
-                    raise scrape_result
-                if isinstance(warmup_result, Exception):
-                    raise warmup_result
-                account_snapshot_ready = True
-            else:
-                await torrent_manager.scrape_torrents(ScrapeContext.LIVE)
-            await _mark_scope_scraped_if_populated(
-                media_id,
-                torrent_manager.torrents,
-            )
-            logger.log(
-                "SCRAPER",
-                f"📥 Torrents after global RTN filtering: {len(torrent_manager.torrents)}",
-            )
-        finally:
-            await cache_manager.release_lock()
-
-    service_cache_status = defaultdict(dict)
-    verified_service_cache_status = defaultdict(dict)
-    show_account_sync_trigger = use_account_scrape
-    if use_account_scrape:
-        if not account_snapshot_ready:
-            await ensure_account_snapshot_ready(session, debrid_entries, ip)
-        await schedule_account_snapshot_refresh(
-            background_tasks, session, debrid_entries, ip
-        )
-        account_torrents, account_cache_status = await get_account_torrents_for_media(
-            debrid_entries,
-            media_type,
-            media_scope,
-            title,
-            year,
-            year_end,
-            search_season,
-            search_episode,
-            aliases,
-            remove_adult_content,
-            target_air_date=target_air_date,
-            reject_unknown_episode_files=reject_unknown_episode_files,
-        )
-
-        for info_hash, account_torrent in account_torrents.items():
-            existing_torrent = torrent_manager.torrents.get(info_hash)
-            if existing_torrent is None:
-                torrent_manager.torrents[info_hash] = account_torrent
-                continue
-
-            if (
-                existing_torrent.get("fileIndex") is None
-                and account_torrent["fileIndex"] is not None
-            ):
-                existing_torrent["fileIndex"] = account_torrent["fileIndex"]
-
-            if (
-                existing_torrent.get("size") is None
-                and account_torrent["size"] is not None
-            ):
-                existing_torrent["size"] = account_torrent["size"]
-
-            existing_parsed = existing_torrent.get("parsed")
-            if existing_parsed is None or str(existing_parsed.resolution) == "unknown":
-                existing_torrent["parsed"] = account_torrent["parsed"]
-
-        if account_torrents:
-            logger.log(
-                "SCRAPER",
-                f"📚 Account scrape added {len(account_torrents)} torrents from debrid snapshots",
-            )
-
-            public_cache_ingested = await ingest_account_torrents_to_public_cache(
-                account_torrents, media_only_id, search_season
-            )
-            if public_cache_ingested:
-                logger.log(
-                    "SCRAPER",
-                    f"🌐 Debrid account contributed {public_cache_ingested} rows to public torrent cache",
-                )
-
-        _merge_service_cache_status(service_cache_status, account_cache_status)
-
-    if debrid_entries:
-        existing_service_cache_status = await check_multi_service_availability(
-            debrid_entries,
-            torrent_manager.torrents,
-            search_season,
-            search_episode,
-            media_scope,
-        )
-        _merge_service_cache_status(service_cache_status, existing_service_cache_status)
-        _merge_service_cache_status(
-            verified_service_cache_status, existing_service_cache_status
-        )
-    elif enable_torrent:
-        await DebridService.apply_cached_availability_any_service(
-            list(torrent_manager.torrents.keys()),
-            search_season,
-            search_episode,
-            media_scope,
-            torrent_manager.torrents,
-        )
-
-    current_info_hashes = set(torrent_manager.torrents)
-    debrid_refresh_hashes = _select_debrid_refresh_hashes(
-        current_info_hashes,
-        initial_info_hashes,
-        verified_service_cache_status,
-        had_cached_torrents=cache_result.has_cached_torrents,
-        use_account_scrape=use_account_scrape,
-    )
-
-    debrid_errors = {}
-    if debrid_entries and debrid_refresh_hashes:
-        services_str = "+".join([e["service"] for e in debrid_entries])
-        logger.log(
-            "SCRAPER",
-            f"🔄 Checking availability on debrid services: {services_str} "
-            f"({len(debrid_refresh_hashes)}/{len(current_info_hashes)} torrents)",
-        )
-        torrents_to_check = {
-            info_hash: torrent
-            for info_hash, torrent in torrent_manager.torrents.items()
-            if info_hash in debrid_refresh_hashes
+    metadata = search_result.metadata
+    title = metadata["title"]
+    media_only_id = search_result.media_only_id
+    search_season = search_result.search_season
+    search_episode = search_result.search_episode
+    service_cache_status = search_result.service_cache_status
+    debrid_errors = search_result.debrid_errors
+    sort_mixed = search_result.sort_mixed
+    torrents = search_result.torrents
+    cached_results = [
+        {
+            "name": (f"[ERROR] {service}" if kodi else f"[❌] {service}"),
+            "description": error.display_message,
+            "url": "https://comet.feels.legal",
         }
-        (
-            fresh_service_cache_status,
-            debrid_errors,
-        ) = await get_and_cache_multi_service_availability(
-            session,
-            debrid_entries,
-            torrents_to_check,
-            media_id,
-            media_only_id,
-            search_season,
-            search_episode,
-            media_scope,
-            ip,
-            target_air_date=target_air_date,
-            known_cache_status=service_cache_status,
-        )
-        _merge_service_cache_status(service_cache_status, fresh_service_cache_status)
-
-        for service, error in debrid_errors.items():
-            cached_results.append(
-                {
-                    "name": (f"[ERROR] {service}" if kodi else f"[❌] {service}"),
-                    "description": error.display_message,
-                    "url": "https://comet.feels.legal",
-                }
-            )
-
+        for service, error in search_result.debrid_errors.items()
+    ]
+    non_cached_results = []
     debrid_stream_specs = [
         (entry_index, entry["service"], get_debrid_extension(entry["service"]))
         for entry_index, entry in enumerate(debrid_entries)
     ]
-    if debrid_stream_specs:
-        seen_services = set()
-        for _, service, _ in debrid_stream_specs:
-            if service in seen_services:
-                continue
-            seen_services.add(service)
-            cached_count = sum(
-                1
-                for cache_map in service_cache_status.values()
-                if cache_map.get(service, False)
-            )
-            logger.log(
-                "SCRAPER",
-                f"💾 Available cached torrents on {service}: {cached_count}/{len(torrent_manager.torrents)}",
-            )
-
-    initial_torrent_count = len(torrent_manager.torrents)
-
-    await torrent_manager.rank_torrents(
-        config["rtnSettings"],
-        config["rtnRanking"],
-        0,
-        config["maxSize"],
-        config["removeTrash"],
-    )
-    logger.log(
-        "SCRAPER",
-        f"⚖️  Torrents after user RTN filtering: {len(torrent_manager.ranked_torrents)}/{initial_torrent_count}",
-    )
 
     if (
         config["debridStreamProxyPassword"] != ""
@@ -1005,7 +379,6 @@ async def stream(
     result_episode = _encode_playback_scope(search_episode)
     quoted_media_only_id = quote(media_only_id, safe="")
 
-    torrents = torrent_manager.torrents
     base_playback_host = (
         settings.PUBLIC_BASE_URL
         if settings.PUBLIC_BASE_URL
@@ -1022,7 +395,7 @@ async def stream(
     torrent_extension = get_debrid_extension("torrent")
     torrent_service = "" if kodi else torrent_extension
 
-    if show_account_sync_trigger:
+    if search_result.show_account_sync_trigger:
         for entry_index, _, debrid_extension in debrid_stream_specs:
             cached_results.append(
                 {
@@ -1040,7 +413,7 @@ async def stream(
             )
 
     selected_info_hashes = _select_info_hashes_by_resolution(
-        ranked_info_hashes=torrent_manager.ranked_torrents,
+        ranked_info_hashes=search_result.ranked_info_hashes,
         torrents=torrents,
         service_cache_status=service_cache_status,
         max_results=config["maxResultsPerResolution"],
@@ -1052,7 +425,7 @@ async def stream(
     ranked_info_hashes = (
         selected_info_hashes
         if selected_info_hashes is not None
-        else torrent_manager.ranked_torrents
+        else search_result.ranked_info_hashes
     )
 
     added_hashes = set()

--- a/comet/api/endpoints/torznab.py
+++ b/comet/api/endpoints/torznab.py
@@ -447,9 +447,15 @@ def _torrent_trackers(torrent: dict) -> list[str]:
 
 
 def build_magnet(info_hash: str, title: str, torrent: dict) -> str:
-    parameters = [("xt", f"urn:btih:{info_hash}"), ("dn", _clean_xml(title))]
+    xt = urlencode(
+        [("xt", f"urn:btih:{info_hash}")],
+        quote_via=quote,
+        safe=":",
+    )
+    parameters = [("dn", _clean_xml(title))]
     parameters.extend(("tr", tracker) for tracker in _torrent_trackers(torrent))
-    return "magnet:?" + urlencode(parameters, doseq=True, quote_via=quote)
+    encoded_parameters = urlencode(parameters, doseq=True, quote_via=quote)
+    return f"magnet:?{xt}&{encoded_parameters}"
 
 
 def _pub_date(value: object, fallback_timestamp: float) -> str:
@@ -475,23 +481,16 @@ def _add_torznab_attribute(item: ET.Element, name: str, value: object) -> None:
     )
 
 
-def _serializable_items(
+def _serializable_torrents(
     result: MediaSearchResult,
-    media_type: str,
-    request_timestamp: float,
-) -> list[ET.Element]:
-    items = []
-    imdb_digits = result.media_only_id.removeprefix("tt")
-    category_id = "2000" if media_type == "movie" else "5000"
-    category_name = "Movies" if media_type == "movie" else "TV"
-
+) -> list[tuple[str, dict, str]]:
+    serializable = []
     for raw_info_hash in result.ranked_info_hashes:
         if (
             not isinstance(raw_info_hash, str)
             or _INFO_HASH.fullmatch(raw_info_hash) is None
         ):
             continue
-        info_hash = raw_info_hash.lower()
         torrent = result.torrents.get(raw_info_hash)
         if not isinstance(torrent, dict):
             continue
@@ -499,9 +498,23 @@ def _serializable_items(
         if not isinstance(raw_title, str) or not raw_title:
             continue
         title = _clean_xml(raw_title)
-        if not title:
-            continue
+        if title:
+            serializable.append((raw_info_hash.lower(), torrent, title))
+    return serializable
 
+
+def _serialize_items(
+    result: MediaSearchResult,
+    media_type: str,
+    request_timestamp: float,
+    candidates: list[tuple[str, dict, str]],
+) -> list[ET.Element]:
+    items = []
+    imdb_digits = result.media_only_id.removeprefix("tt")
+    category_id = "2000" if media_type == "movie" else "5000"
+    category_name = "Movies" if media_type == "movie" else "TV"
+
+    for info_hash, torrent, title in candidates:
         raw_size = torrent.get("size")
         size = (
             raw_size
@@ -576,13 +589,22 @@ def serialize_feed(
     request_timestamp: float | None = None,
 ) -> tuple[bytes, int, int]:
     timestamp = request_timestamp if request_timestamp is not None else time.time()
-    items = (
-        _serializable_items(result, media_type, timestamp)
+    candidates = (
+        _serializable_torrents(result)
         if result is not None and media_type is not None
         else []
     )
-    total = len(items)
-    page = items[offset : offset + limit]
+    total = len(candidates)
+    page = (
+        _serialize_items(
+            result,
+            media_type,
+            timestamp,
+            candidates[offset : offset + limit],
+        )
+        if result is not None and media_type is not None
+        else []
+    )
 
     rss = ET.Element(
         "rss",

--- a/comet/api/endpoints/torznab.py
+++ b/comet/api/endpoints/torznab.py
@@ -1,0 +1,840 @@
+import math
+import re
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from email.utils import format_datetime
+from urllib.parse import quote, urlencode, urlsplit
+
+from fastapi import APIRouter, BackgroundTasks, Request, Response
+
+from comet.core.config_validation import config_check
+from comet.core.logger import logger
+from comet.core.models import database, settings
+from comet.metadata.episode_index import EpisodeIndexService
+from comet.metadata.imdb import resolve_imdb_title
+from comet.metadata.tmdb import TMDBApi
+from comet.observability import metrics
+from comet.services.media_search import MediaSearchResult, MediaSearchStatus, search_media
+from comet.services.trackers import trackers as global_trackers
+from comet.utils.cache import (
+    CachePolicies,
+    check_etag_match,
+    generate_etag,
+    not_modified_response,
+)
+from comet.utils.http_client import http_client_manager
+from comet.utils.network import get_client_ip
+from comet.utils.parsing import MediaScope, parse_media_id
+from comet.utils.torrent_cache import build_torrent_cache_where
+
+router = APIRouter()
+
+TORZNAB_NAMESPACE = "http://torznab.com/schemas/2015/feed"
+NEWZNAB_NAMESPACE = "http://www.newznab.com/DTD/2010/feeds/attributes/"
+MAX_RESULTS = 100
+RECENT_CANDIDATE_LIMIT = 20
+
+ET.register_namespace("torznab", TORZNAB_NAMESPACE)
+ET.register_namespace("newznab", NEWZNAB_NAMESPACE)
+
+_IMDB_ID = re.compile(r"tt([0-9]{7,10})", re.IGNORECASE)
+_IMDB_ID_WITHOUT_PREFIX = re.compile(r"[0-9]{7,10}")
+_NONNEGATIVE_INTEGER = re.compile(r"[0-9]{1,18}", re.ASCII)
+_YEAR = re.compile(r"[0-9]{4}", re.ASCII)
+_SEASON = re.compile(r"[sS]?([0-9]{1,4})", re.ASCII)
+_EPISODE = re.compile(r"[eE]?([0-9]{1,6})", re.ASCII)
+_DAILY_EPISODE = re.compile(r"([0-9]{1,2})/([0-9]{1,2})", re.ASCII)
+_TITLE_SCOPE = re.compile(
+    r"(?i)(?:[ ._-]+)S([0-9]{1,4})(?:E([0-9]{1,6}))?\s*$"
+)
+_INFO_HASH = re.compile(r"[0-9a-fA-F]{40}", re.ASCII)
+
+
+class TorznabProtocolError(ValueError):
+    def __init__(self, code: int, description: str):
+        super().__init__(description)
+        self.code = code
+        self.description = description
+
+
+@dataclass(frozen=True, slots=True)
+class TorznabQuery:
+    function: str
+    query: str | None
+    imdb_id: str | None
+    season: int | None
+    episode: int | str | None
+    year: int | None
+    categories: tuple[int, ...]
+    offset: int
+    limit: int
+
+
+@dataclass(frozen=True, slots=True)
+class CategoryConstraint:
+    media_type: str | None
+    unsupported_only: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SearchTarget:
+    media_type: str
+    media_id: str
+
+
+def _clean_xml(value: object) -> str:
+    text = str(value)
+    return "".join(
+        character
+        for character in text
+        if (
+            ord(character) in (0x09, 0x0A, 0x0D)
+            or 0x20 <= ord(character) <= 0xD7FF
+            or 0xE000 <= ord(character) <= 0xFFFD
+            or 0x10000 <= ord(character) <= 0x10FFFF
+        )
+    )
+
+
+def _xml_bytes(root: ET.Element) -> bytes:
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _normalize_imdb_id(value: str, *, prefix_optional: bool) -> str:
+    normalized = value.strip()
+    match = _IMDB_ID.fullmatch(normalized)
+    if match is not None:
+        return f"tt{match.group(1)}"
+    if prefix_optional and _IMDB_ID_WITHOUT_PREFIX.fullmatch(normalized):
+        return f"tt{normalized}"
+    raise TorznabProtocolError(201, "Invalid parameter")
+
+
+def _parse_nonnegative(value: str, *, limit: bool = False) -> int:
+    if _NONNEGATIVE_INTEGER.fullmatch(value.strip()) is None:
+        raise TorznabProtocolError(201, "Invalid parameter")
+    parsed = int(value)
+    return min(parsed, MAX_RESULTS) if limit else parsed
+
+
+def parse_torznab_query(request: Request) -> TorznabQuery:
+    values: dict[str, str] = {}
+    category_values = []
+    for raw_name, raw_value in request.query_params.multi_items():
+        name = raw_name.casefold()
+        if name == "cat":
+            category_values.append(raw_value)
+        else:
+            values[name] = raw_value
+
+    function = values.get("t", "caps").strip().casefold() or "caps"
+    if function == "get":
+        raise TorznabProtocolError(203, "Function not available")
+    if function not in {"caps", "search", "movie", "tvsearch"}:
+        raise TorznabProtocolError(202, "Unknown function")
+
+    output = values.get("o", "").strip().casefold()
+    if output not in {"", "xml"}:
+        raise TorznabProtocolError(201, "Invalid parameter")
+    if function == "caps":
+        return TorznabQuery(function, None, None, None, None, None, (), 0, MAX_RESULTS)
+
+    categories = []
+    for category_group in category_values:
+        for category in category_group.split(","):
+            if not category.strip():
+                raise TorznabProtocolError(201, "Invalid parameter")
+            categories.append(_parse_nonnegative(category))
+
+    raw_season = values.get("season")
+    season = None
+    if raw_season is not None:
+        match = _SEASON.fullmatch(raw_season.strip())
+        if match is None:
+            raise TorznabProtocolError(201, "Invalid parameter")
+        season = int(match.group(1))
+
+    raw_episode = values.get("ep")
+    episode: int | str | None = None
+    if raw_episode is not None:
+        episode_value = raw_episode.strip()
+        daily_match = _DAILY_EPISODE.fullmatch(episode_value)
+        if daily_match is not None:
+            episode = f"{int(daily_match.group(1)):02d}/{int(daily_match.group(2)):02d}"
+        else:
+            episode_match = _EPISODE.fullmatch(episode_value)
+            if episode_match is None:
+                raise TorznabProtocolError(201, "Invalid parameter")
+            episode = int(episode_match.group(1))
+
+    raw_year = values.get("year")
+    year = None
+    if raw_year is not None:
+        if _YEAR.fullmatch(raw_year.strip()) is None:
+            raise TorznabProtocolError(201, "Invalid parameter")
+        year = int(raw_year)
+
+    if isinstance(episode, str) and season is not None:
+        if raw_season is None or _YEAR.fullmatch(raw_season.strip()) is None:
+            raise TorznabProtocolError(201, "Invalid parameter")
+        month, day = (int(value) for value in episode.split("/", 1))
+        try:
+            date(season, month, day)
+        except ValueError as exc:
+            raise TorznabProtocolError(201, "Invalid parameter") from exc
+
+    imdb_id = values.get("imdbid")
+    if imdb_id is not None:
+        imdb_id = _normalize_imdb_id(imdb_id, prefix_optional=True)
+
+    offset = _parse_nonnegative(values.get("offset", "0"))
+    result_limit = _parse_nonnegative(values.get("limit", str(MAX_RESULTS)), limit=True)
+    query = values.get("q")
+    if query is not None:
+        query = query.strip()
+
+    return TorznabQuery(
+        function,
+        query,
+        imdb_id,
+        season,
+        episode,
+        year,
+        tuple(categories),
+        offset,
+        result_limit,
+    )
+
+
+def category_constraint(categories: tuple[int, ...]) -> CategoryConstraint:
+    has_movies = any(2000 <= category <= 2999 for category in categories)
+    has_tv = any(5000 <= category <= 5999 for category in categories)
+    if categories and not has_movies and not has_tv:
+        return CategoryConstraint(None, True)
+    if has_movies == has_tv:
+        return CategoryConstraint(None, False)
+    return CategoryConstraint("movie" if has_movies else "series", False)
+
+
+def _function_media_type(function: str) -> str | None:
+    if function == "movie":
+        return "movie"
+    if function == "tvsearch":
+        return "series"
+    return None
+
+
+def _extract_title_scope(
+    query: str,
+    season: int | None,
+    episode: int | str | None,
+) -> tuple[str, int | None, int | str | None]:
+    match = _TITLE_SCOPE.search(query)
+    if match is None:
+        return query, season, episode
+    title = query[: match.start()].strip(" ._-")
+    if season is None:
+        season = int(match.group(1))
+    if episode is None and match.group(2) is not None:
+        episode = int(match.group(2))
+    return title, season, episode
+
+
+async def _resolve_daily_episode(
+    imdb_id: str,
+    year: int,
+    episode: str,
+    session,
+) -> tuple[int, int] | None:
+    month, day = (int(value) for value in episode.split("/", 1))
+    try:
+        air_date = date(year, month, day).isoformat()
+    except ValueError as exc:
+        raise TorznabProtocolError(201, "Invalid parameter") from exc
+    return await EpisodeIndexService(session).get_episode_by_air_date(
+        imdb_id, air_date
+    )
+
+
+async def resolve_search_target(
+    query: TorznabQuery,
+    constraint: CategoryConstraint,
+    session,
+) -> SearchTarget | None:
+    function_type = _function_media_type(query.function)
+    if (
+        function_type is not None
+        and constraint.media_type is not None
+        and function_type != constraint.media_type
+    ):
+        return None
+
+    season = query.season
+    episode = query.episode
+    if function_type == "movie" and (season is not None or episode is not None):
+        raise TorznabProtocolError(201, "Invalid parameter")
+    if episode is not None and season is None:
+        raise TorznabProtocolError(201, "Invalid parameter")
+
+    imdb_id = query.imdb_id
+    title_query = query.query or ""
+    if title_query:
+        imdb_match = _IMDB_ID.fullmatch(title_query)
+        if imdb_match is not None and imdb_id is None:
+            imdb_id = f"tt{imdb_match.group(1)}"
+        elif imdb_match is None:
+            title_query, season, episode = _extract_title_scope(
+                title_query, season, episode
+            )
+
+    forced_type = function_type or constraint.media_type
+    if forced_type is None and (season is not None or episode is not None):
+        forced_type = "series"
+
+    resolved_type = forced_type
+    if imdb_id is None:
+        if not title_query:
+            raise TorznabProtocolError(200, "Missing parameter")
+        match = await resolve_imdb_title(
+            session,
+            title_query,
+            media_type=forced_type,
+            year=query.year,
+        )
+        if match is None:
+            return None
+        imdb_id = match.imdb_id
+        if resolved_type is None:
+            resolved_type = match.media_type
+    elif resolved_type is None:
+        resolved_type = await TMDBApi(session).get_media_type_from_imdb(imdb_id)
+        if resolved_type is None:
+            return None
+
+    if constraint.media_type is not None and resolved_type != constraint.media_type:
+        return None
+
+    if resolved_type == "movie":
+        if season is not None or episode is not None:
+            raise TorznabProtocolError(201, "Invalid parameter")
+        return SearchTarget("movie", imdb_id)
+    if resolved_type != "series":
+        return None
+
+    if isinstance(episode, str):
+        if season is None:
+            raise TorznabProtocolError(201, "Invalid parameter")
+        daily_scope = await _resolve_daily_episode(imdb_id, season, episode, session)
+        if daily_scope is None:
+            return None
+        season, episode = daily_scope
+
+    media_id = imdb_id
+    if season is not None:
+        media_id += f":{int(season)}"
+        if episode is not None:
+            media_id += f":{int(episode)}"
+    return SearchTarget("series", media_id)
+
+
+async def _candidate_torrent_row(media_id: str):
+    try:
+        _, season, episode = parse_media_id("series", media_id)
+    except ValueError:
+        return await database.fetch_one(
+            """
+            SELECT info_hash, season, episode
+            FROM torrents
+            WHERE media_id = :media_id
+            LIMIT 1
+            """,
+            {"media_id": media_id},
+        )
+
+    scope = (
+        MediaScope.EPISODE
+        if episode is not None
+        else MediaScope.SEASON
+        if season is not None
+        else MediaScope.SERIES
+    )
+    where_clause, params = build_torrent_cache_where(
+        media_id.split(":", 1)[0], scope, season, episode
+    )
+    return await database.fetch_one(
+        "SELECT info_hash, season, episode " + where_clause + " LIMIT 1",
+        params,
+    )
+
+
+async def find_recent_target(
+    constraint: CategoryConstraint,
+    session,
+) -> SearchTarget | None:
+    rows = await database.fetch_all(
+        """
+        SELECT media_id
+        FROM media_demand
+        WHERE last_scraped_at IS NOT NULL
+        ORDER BY last_scraped_at DESC
+        LIMIT :limit
+        """,
+        {"limit": RECENT_CANDIDATE_LIMIT},
+    )
+
+    type_lookup_used = False
+    for row in rows:
+        media_id = row["media_id"]
+        if not isinstance(media_id, str) or media_id.startswith("kitsu:"):
+            continue
+        try:
+            imdb_id, season, episode = parse_media_id("series", media_id)
+        except ValueError:
+            continue
+
+        torrent_row = await _candidate_torrent_row(media_id)
+        if torrent_row is None:
+            continue
+
+        scoped_series = season is not None or episode is not None
+        locally_series = scoped_series or torrent_row["season"] is not None or torrent_row[
+            "episode"
+        ] is not None
+        if locally_series:
+            if constraint.media_type == "movie":
+                continue
+            return SearchTarget("series", media_id)
+
+        if type_lookup_used:
+            continue
+        type_lookup_used = True
+        media_type = await TMDBApi(session).get_media_type_from_imdb(imdb_id)
+        if constraint.media_type is not None and media_type != constraint.media_type:
+            continue
+        if media_type == "movie":
+            return SearchTarget("movie", imdb_id)
+        if media_type == "series":
+            return SearchTarget("series", media_id)
+
+    return None
+
+
+def _valid_tracker(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = _clean_xml(value.strip())
+    if normalized.casefold().startswith("tracker:"):
+        normalized = normalized[8:].strip()
+    parsed = urlsplit(normalized)
+    if parsed.scheme.casefold() not in {"http", "https", "udp"} or not parsed.hostname:
+        return None
+    return normalized
+
+
+def _torrent_trackers(torrent: dict) -> list[str]:
+    candidates = torrent.get("sources") or global_trackers
+    normalized = []
+    seen = set()
+    for candidate in candidates:
+        tracker = _valid_tracker(candidate)
+        if tracker is None or tracker in seen:
+            continue
+        seen.add(tracker)
+        normalized.append(tracker)
+    return normalized
+
+
+def build_magnet(info_hash: str, title: str, torrent: dict) -> str:
+    parameters = [("xt", f"urn:btih:{info_hash}"), ("dn", _clean_xml(title))]
+    parameters.extend(("tr", tracker) for tracker in _torrent_trackers(torrent))
+    return "magnet:?" + urlencode(parameters, doseq=True, quote_via=quote)
+
+
+def _pub_date(value: object, fallback_timestamp: float) -> str:
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        timestamp = fallback_timestamp
+    if not math.isfinite(timestamp) or timestamp <= 0:
+        timestamp = fallback_timestamp
+    try:
+        return format_datetime(datetime.fromtimestamp(timestamp, UTC), usegmt=True)
+    except (OverflowError, OSError, ValueError):
+        return format_datetime(
+            datetime.fromtimestamp(fallback_timestamp, UTC), usegmt=True
+        )
+
+
+def _add_torznab_attribute(item: ET.Element, name: str, value: object) -> None:
+    ET.SubElement(
+        item,
+        "torznab:attr",
+        {"name": name, "value": _clean_xml(value)},
+    )
+
+
+def _serializable_items(
+    result: MediaSearchResult,
+    media_type: str,
+    request_timestamp: float,
+) -> list[ET.Element]:
+    items = []
+    imdb_digits = result.media_only_id.removeprefix("tt")
+    category_id = "2000" if media_type == "movie" else "5000"
+    category_name = "Movies" if media_type == "movie" else "TV"
+
+    for raw_info_hash in result.ranked_info_hashes:
+        if (
+            not isinstance(raw_info_hash, str)
+            or _INFO_HASH.fullmatch(raw_info_hash) is None
+        ):
+            continue
+        info_hash = raw_info_hash.lower()
+        torrent = result.torrents.get(raw_info_hash)
+        if not isinstance(torrent, dict):
+            continue
+        raw_title = torrent.get("title")
+        if not isinstance(raw_title, str) or not raw_title:
+            continue
+        title = _clean_xml(raw_title)
+        if not title:
+            continue
+
+        raw_size = torrent.get("size")
+        size = (
+            raw_size
+            if type(raw_size) is int and raw_size >= 0
+            else 0
+        )
+        magnet = _clean_xml(build_magnet(info_hash, title, torrent))
+        item = ET.Element("item")
+        ET.SubElement(item, "title").text = title
+        ET.SubElement(item, "guid", {"isPermaLink": "false"}).text = info_hash
+        ET.SubElement(item, "pubDate").text = _pub_date(
+            torrent.get("updatedAt"), request_timestamp
+        )
+        ET.SubElement(item, "link").text = magnet
+        ET.SubElement(item, "category").text = category_name
+        ET.SubElement(item, "size").text = str(size)
+        ET.SubElement(
+            item,
+            "enclosure",
+            {
+                "url": magnet,
+                "length": str(size),
+                "type": "application/x-bittorrent;x-scheme-handler/magnet",
+            },
+        )
+
+        _add_torznab_attribute(item, "category", category_id)
+        _add_torznab_attribute(item, "size", size)
+        _add_torznab_attribute(item, "infohash", info_hash)
+        _add_torznab_attribute(item, "magneturl", magnet)
+        _add_torznab_attribute(item, "imdb", imdb_digits)
+
+        seeders = torrent.get("seeders")
+        if type(seeders) is int and seeders >= 0:
+            _add_torznab_attribute(item, "seeders", seeders)
+        if media_type == "series":
+            if result.search_season is not None:
+                _add_torznab_attribute(item, "season", result.search_season)
+            if result.search_episode is not None:
+                _add_torznab_attribute(item, "episode", result.search_episode)
+
+        parsed = torrent.get("parsed")
+        if parsed is not None:
+            parsed_year = getattr(parsed, "year", None)
+            if type(parsed_year) is int and parsed_year > 0:
+                _add_torznab_attribute(item, "year", parsed_year)
+            languages = getattr(parsed, "languages", None)
+            if isinstance(languages, list):
+                language = ",".join(
+                    _clean_xml(value)
+                    for value in languages
+                    if isinstance(value, str) and value
+                )
+                if language:
+                    _add_torznab_attribute(item, "language", language)
+            resolution = str(getattr(parsed, "resolution", "") or "")
+            if resolution and resolution.casefold() != "unknown":
+                _add_torznab_attribute(item, "resolution", resolution)
+
+        items.append(item)
+
+    return items
+
+
+def serialize_feed(
+    result: MediaSearchResult | None,
+    media_type: str | None,
+    offset: int,
+    limit: int,
+    link: str,
+    *,
+    request_timestamp: float | None = None,
+) -> tuple[bytes, int, int]:
+    timestamp = request_timestamp if request_timestamp is not None else time.time()
+    items = (
+        _serializable_items(result, media_type, timestamp)
+        if result is not None and media_type is not None
+        else []
+    )
+    total = len(items)
+    page = items[offset : offset + limit]
+
+    rss = ET.Element(
+        "rss",
+        {
+            "version": "2.0",
+            "xmlns:torznab": TORZNAB_NAMESPACE,
+            "xmlns:newznab": NEWZNAB_NAMESPACE,
+        },
+    )
+    channel = ET.SubElement(rss, "channel")
+    ET.SubElement(channel, "title").text = "Comet"
+    ET.SubElement(channel, "description").text = "Comet torrent results"
+    ET.SubElement(channel, "link").text = _clean_xml(link)
+    ET.SubElement(channel, "language").text = "en"
+    ET.SubElement(
+        channel,
+        "newznab:response",
+        {"offset": str(offset), "total": str(total)},
+    )
+    channel.extend(page)
+    return _xml_bytes(rss), total, len(page)
+
+
+def serialize_caps() -> bytes:
+    available = "no" if settings.DISABLE_TORRENT_STREAMS else "yes"
+    caps = ET.Element("caps")
+    ET.SubElement(caps, "server", {"version": "1.3", "title": "Comet"})
+    ET.SubElement(
+        caps,
+        "limits",
+        {"max": str(MAX_RESULTS), "default": str(MAX_RESULTS)},
+    )
+    searching = ET.SubElement(caps, "searching")
+    ET.SubElement(
+        searching,
+        "search",
+        {"available": available, "supportedParams": "q"},
+    )
+    ET.SubElement(
+        searching,
+        "tv-search",
+        {
+            "available": available,
+            "supportedParams": "q,imdbid,season,ep",
+        },
+    )
+    ET.SubElement(
+        searching,
+        "movie-search",
+        {"available": available, "supportedParams": "q,imdbid"},
+    )
+    categories = ET.SubElement(caps, "categories")
+    ET.SubElement(categories, "category", {"id": "2000", "name": "Movies"})
+    ET.SubElement(categories, "category", {"id": "5000", "name": "TV"})
+    return _xml_bytes(caps)
+
+
+def serialize_error(code: int, description: str) -> bytes:
+    return _xml_bytes(
+        ET.Element(
+            "error",
+            {"code": str(code), "description": _clean_xml(description)},
+        )
+    )
+
+
+def _xml_response(
+    request: Request,
+    content: bytes,
+    *,
+    feed: bool,
+    cache_policy=None,
+):
+    content_type = (
+        "application/rss+xml; charset=utf-8"
+        if feed
+        else "application/xml; charset=utf-8"
+    )
+    if not settings.HTTP_CACHE_ENABLED:
+        return Response(content=content, headers={"Content-Type": content_type})
+
+    policy = cache_policy or CachePolicies.empty_results()
+    cache_control = policy.build()
+    etag = generate_etag(content)
+    if check_etag_match(request, etag):
+        return not_modified_response(etag, cache_control=cache_control)
+    return Response(
+        content=content,
+        headers={
+            "Content-Type": content_type,
+            "Cache-Control": cache_control,
+            "ETag": etag,
+            "Vary": "Accept, Accept-Encoding",
+        },
+    )
+
+
+def _protocol_error_response(
+    request: Request,
+    error: TorznabProtocolError,
+    *,
+    no_store: bool = False,
+):
+    policy = CachePolicies.no_cache() if no_store else CachePolicies.empty_results()
+    return _xml_response(
+        request,
+        serialize_error(error.code, error.description),
+        feed=False,
+        cache_policy=policy,
+    )
+
+
+def _request_link(request: Request) -> str:
+    return f"{str(request.base_url).rstrip('/')}{request.url.path}"
+
+
+@router.get(
+    "/torznab/api",
+    tags=["Stremio"],
+    summary="Torznab API",
+    description="Returns capabilities and torrent search feeds.",
+)
+async def torznab_api(
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
+    try:
+        query = parse_torznab_query(request)
+        if query.function == "caps":
+            return _xml_response(
+                request,
+                serialize_caps(),
+                feed=False,
+                cache_policy=CachePolicies.manifest(),
+            )
+
+        if settings.DISABLE_TORRENT_STREAMS:
+            raise TorznabProtocolError(203, "Function not available")
+
+        constraint = category_constraint(query.categories)
+        if constraint.unsupported_only:
+            content, _, _ = serialize_feed(
+                None, None, query.offset, query.limit, _request_link(request)
+            )
+            return _xml_response(
+                request,
+                content,
+                feed=True,
+                cache_policy=CachePolicies.empty_results(),
+            )
+
+        function_type = _function_media_type(query.function)
+        if (
+            function_type is not None
+            and constraint.media_type is not None
+            and function_type != constraint.media_type
+        ):
+            content, _, _ = serialize_feed(
+                None, None, query.offset, query.limit, _request_link(request)
+            )
+            return _xml_response(
+                request,
+                content,
+                feed=True,
+                cache_policy=CachePolicies.empty_results(),
+            )
+
+        session = await http_client_manager.get_session()
+        if (
+            query.function == "search"
+            and query.imdb_id is None
+            and not query.query
+        ):
+            if query.season is not None or query.episode is not None:
+                raise TorznabProtocolError(200, "Missing parameter")
+            target = await find_recent_target(constraint, session)
+        else:
+            target = await resolve_search_target(query, constraint, session)
+
+        if target is None:
+            content, _, _ = serialize_feed(
+                None, None, query.offset, query.limit, _request_link(request)
+            )
+            return _xml_response(
+                request,
+                content,
+                feed=True,
+                cache_policy=CachePolicies.empty_results(),
+            )
+
+        config = config_check(None, strict_b64config=True)
+        if config is None:
+            raise RuntimeError("Default configuration is unavailable")
+        result = await search_media(
+            target.media_type,
+            target.media_id,
+            config,
+            get_client_ip(request),
+            background_tasks.add_task,
+        )
+
+        if result.status is MediaSearchStatus.INVALID:
+            raise TorznabProtocolError(201, "Invalid parameter")
+        if result.status is MediaSearchStatus.DISABLED:
+            raise TorznabProtocolError(203, "Function not available")
+        if result.status is MediaSearchStatus.BUSY:
+            raise TorznabProtocolError(900, "Search busy; retry shortly")
+
+        empty_statuses = {
+            MediaSearchStatus.UNRELEASED,
+            MediaSearchStatus.METADATA_UNAVAILABLE,
+        }
+        if result.status in empty_statuses:
+            content, total, page_count = serialize_feed(
+                None, None, query.offset, query.limit, _request_link(request)
+            )
+        else:
+            content, total, page_count = serialize_feed(
+                result,
+                target.media_type,
+                query.offset,
+                query.limit,
+                _request_link(request),
+            )
+
+        metrics.observe_stream(
+            target.media_type,
+            "torznab",
+            result.cache_state,
+            "empty" if total == 0 else "success",
+            page_count,
+        )
+        return _xml_response(
+            request,
+            content,
+            feed=True,
+            cache_policy=(
+                CachePolicies.streams()
+                if total
+                else CachePolicies.empty_results()
+            ),
+        )
+    except TorznabProtocolError as error:
+        return _protocol_error_response(
+            request,
+            error,
+            no_store=error.code == 900,
+        )
+    except Exception:
+        logger.exception("Unexpected Torznab request failure")
+        return _protocol_error_response(
+            request,
+            TorznabProtocolError(900, "Backend error"),
+            no_store=True,
+        )

--- a/comet/metadata/episode_index.py
+++ b/comet/metadata/episode_index.py
@@ -22,6 +22,19 @@ _TARGET_EPISODE_AIR_DATE_QUERY = """
       )
 """
 
+_EPISODE_BY_AIR_DATE_QUERY = """
+    SELECT season, episode
+    FROM series_episode_index
+    WHERE series_id = :series_id
+      AND air_date = :air_date
+      AND (
+          CAST(:min_timestamp AS REAL) IS NULL
+          OR updated_at >= CAST(:min_timestamp AS REAL)
+      )
+    ORDER BY season, episode
+    LIMIT 1
+"""
+
 _SERIES_INDEX_LAST_REFRESH_QUERY = """
     SELECT refreshed_at
     FROM series_episode_index_refresh
@@ -102,6 +115,24 @@ class EpisodeIndexService:
         if row is None:
             return None
         return _normalize_air_date(row["air_date"])
+
+    async def _get_cached_episode(
+        self,
+        series_id: str,
+        air_date: str,
+        min_timestamp: float | None,
+    ) -> tuple[int, int] | None:
+        row = await database.fetch_one(
+            _EPISODE_BY_AIR_DATE_QUERY,
+            {
+                "series_id": series_id,
+                "air_date": air_date,
+                "min_timestamp": min_timestamp,
+            },
+        )
+        if row is None:
+            return None
+        return int(row["season"]), int(row["episode"])
 
     async def _is_series_index_fresh(
         self, series_id: str, min_timestamp: float
@@ -283,3 +314,33 @@ class EpisodeIndexService:
             return tmdb_air_date
 
         return await self._get_cached_air_date(series_id, season, episode, None)
+
+    async def get_episode_by_air_date(
+        self,
+        series_id: str,
+        air_date: str,
+    ) -> tuple[int, int] | None:
+        normalized_air_date = _normalize_air_date(air_date)
+        if (
+            not isinstance(series_id, str)
+            or not series_id.startswith("tt")
+            or normalized_air_date is None
+        ):
+            return None
+
+        min_timestamp = time.time() - settings.METADATA_CACHE_TTL
+        cached_episode = await self._get_cached_episode(
+            series_id, normalized_air_date, min_timestamp
+        )
+        if cached_episode is not None:
+            return cached_episode
+
+        if not await self._is_series_index_fresh(series_id, min_timestamp):
+            await self._refresh_from_cinemeta(series_id)
+            cached_episode = await self._get_cached_episode(
+                series_id, normalized_air_date, min_timestamp
+            )
+            if cached_episode is not None:
+                return cached_episode
+
+        return await self._get_cached_episode(series_id, normalized_air_date, None)

--- a/comet/metadata/imdb.py
+++ b/comet/metadata/imdb.py
@@ -1,3 +1,7 @@
+import re
+from dataclasses import dataclass
+from urllib.parse import quote
+
 import aiohttp
 
 from comet.core.logger import logger
@@ -6,6 +10,103 @@ from comet.utils.year import parse_year, parse_year_range
 _IMDB_SUGGESTION_URL = "https://v3.sg.media-imdb.com/suggestion/a/{id}.json"
 _CINEMETA_META_URL = "https://v3-cinemeta.strem.io/meta/{media_type}/{id}.json"
 _CINEMETA_MEDIA_TYPES = ("movie", "series")
+_IMDB_ID = re.compile(r"tt[0-9]{7,10}")
+_MOVIE_TYPES = frozenset(
+    {
+        "feature",
+        "movie",
+        "short",
+        "tvmovie",
+        "tvshort",
+        "video",
+    }
+)
+_SERIES_TYPES = frozenset(
+    {
+        "miniseries",
+        "series",
+        "tvminiseries",
+        "tvseries",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ImdbTitleMatch:
+    imdb_id: str
+    media_type: str
+    year: int | None
+
+
+def _suggestion_media_type(element: dict) -> str | None:
+    for key in ("qid", "q"):
+        raw_value = element.get(key)
+        if not isinstance(raw_value, str):
+            continue
+        normalized = "".join(
+            character for character in raw_value.lower() if character.isalnum()
+        )
+        if normalized in _MOVIE_TYPES:
+            return "movie"
+        if normalized in _SERIES_TYPES:
+            return "series"
+    return None
+
+
+def _extract_title_match(
+    payload: object,
+    media_type: str | None = None,
+    year: int | None = None,
+) -> ImdbTitleMatch | None:
+    if not isinstance(payload, dict) or not isinstance(payload.get("d"), list):
+        return None
+
+    for element in payload["d"]:
+        if not isinstance(element, dict):
+            continue
+        imdb_id = element.get("id")
+        if not isinstance(imdb_id, str) or _IMDB_ID.fullmatch(imdb_id) is None:
+            continue
+        candidate_type = _suggestion_media_type(element)
+        if candidate_type is None or (
+            media_type is not None and candidate_type != media_type
+        ):
+            continue
+        candidate_year = parse_year(element.get("y"))
+        if year is not None and candidate_year != year:
+            continue
+        return ImdbTitleMatch(imdb_id, candidate_type, candidate_year)
+
+    return None
+
+
+async def resolve_imdb_title(
+    session: aiohttp.ClientSession,
+    query: str,
+    media_type: str | None = None,
+    year: int | None = None,
+) -> ImdbTitleMatch | None:
+    normalized_query = query.strip()
+    if not normalized_query:
+        return None
+
+    url = _IMDB_SUGGESTION_URL.format(id=quote(normalized_query, safe=""))
+    try:
+        async with session.get(url) as response:
+            if response.status != 200:
+                logger.warning(
+                    f"IMDb title search failed for {normalized_query!r}: "
+                    f"HTTP {response.status}"
+                )
+                return None
+            payload = await response.json()
+    except Exception as exc:
+        logger.warning(
+            f"IMDb title search failed for {normalized_query!r}: {exc}"
+        )
+        return None
+
+    return _extract_title_match(payload, media_type, year)
 
 
 def _extract_imdb_metadata(payload: dict) -> tuple[str | None, int | None, int | None]:

--- a/comet/metadata/imdb.py
+++ b/comet/metadata/imdb.py
@@ -61,6 +61,7 @@ def _extract_title_match(
     if not isinstance(payload, dict) or not isinstance(payload.get("d"), list):
         return None
 
+    nearest_match = None
     for element in payload["d"]:
         if not isinstance(element, dict):
             continue
@@ -73,11 +74,15 @@ def _extract_title_match(
         ):
             continue
         candidate_year = parse_year(element.get("y"))
-        if year is not None and candidate_year != year:
+        match = ImdbTitleMatch(imdb_id, candidate_type, candidate_year)
+        if year is None or candidate_year == year:
+            return match
+        if candidate_year is None or abs(candidate_year - year) > 1:
             continue
-        return ImdbTitleMatch(imdb_id, candidate_type, candidate_year)
+        if nearest_match is None:
+            nearest_match = match
 
-    return None
+    return nearest_match
 
 
 async def resolve_imdb_title(

--- a/comet/services/debrid_account_scraper.py
+++ b/comet/services/debrid_account_scraper.py
@@ -516,7 +516,7 @@ async def ingest_account_torrents_to_public_cache(
 
 
 async def schedule_account_snapshot_refresh(
-    background_tasks,
+    add_background_task,
     session,
     debrid_entries: list[dict],
     ip: str,
@@ -562,7 +562,7 @@ async def schedule_account_snapshot_refresh(
         if not lock_acquired:
             continue
 
-        background_tasks.add_task(
+        add_background_task(
             _sync_task,
             lock,
             session,

--- a/comet/services/media_search.py
+++ b/comet/services/media_search.py
@@ -1,0 +1,751 @@
+import asyncio
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from comet.core.logger import logger
+from comet.core.models import settings
+from comet.core.scrape import ScrapeContext
+from comet.debrid.exceptions import DebridAuthError
+from comet.metadata.episode_index import EpisodeIndexService
+from comet.metadata.filter import release_filter
+from comet.metadata.manager import MetadataScraper
+from comet.observability import metrics
+from comet.services.anime import anime_mapper
+from comet.services.cache_state import CacheStateManager, mark_scope_scraped
+from comet.services.debrid import DebridService
+from comet.services.debrid_account_scraper import (
+    ensure_account_snapshot_ready,
+    get_account_torrents_for_media,
+    ingest_account_torrents_to_public_cache,
+    schedule_account_snapshot_refresh,
+)
+from comet.services.lock import DistributedLock
+from comet.services.orchestration import TorrentManager
+from comet.utils.http_client import http_client_manager
+from comet.utils.parsing import MediaScope, parse_media_id, resolve_media_scope
+
+BackgroundTaskAdder = Callable[..., Any]
+
+
+class MediaSearchStatus(StrEnum):
+    OK = "ok"
+    INVALID = "invalid"
+    DISABLED = "disabled"
+    UNRELEASED = "unreleased"
+    METADATA_UNAVAILABLE = "metadata_unavailable"
+    BUSY = "busy"
+
+
+@dataclass(slots=True)
+class MediaSearchResult:
+    status: MediaSearchStatus
+    metadata: dict = field(default_factory=dict)
+    aliases: dict = field(default_factory=dict)
+    media_scope: MediaScope | None = None
+    torrents: dict = field(default_factory=dict)
+    ranked_info_hashes: list[str] = field(default_factory=list)
+    service_cache_status: dict = field(default_factory=dict)
+    debrid_errors: dict = field(default_factory=dict)
+    cache_state: str = "unknown"
+    media_only_id: str = ""
+    search_season: int | None = None
+    search_episode: int | None = None
+    is_torrent_only: bool = False
+    sort_mixed: bool = False
+    show_account_sync_trigger: bool = False
+    use_account_scrape: bool = False
+
+
+def episode_matching_policy(
+    media_type: str,
+    media_only_id: str,
+    search_season: int | None,
+    search_episode: int | None,
+    *,
+    cached_only: bool,
+    has_debrid: bool,
+    enable_torrent: bool,
+) -> tuple[bool, bool]:
+    is_imdb_episode_request = (
+        media_type == "series"
+        and search_season is not None
+        and search_episode is not None
+        and media_only_id.startswith("tt")
+    )
+    allow_debrid_verified_season_packs = (
+        is_imdb_episode_request and cached_only and has_debrid and not enable_torrent
+    )
+    reject_unknown_episode_files = (
+        is_imdb_episode_request and not allow_debrid_verified_season_packs
+    )
+    return is_imdb_episode_request, reject_unknown_episode_files
+
+
+def merge_service_cache_status(target: dict, incoming: dict):
+    for info_hash, service_map in incoming.items():
+        cache_map = target.setdefault(info_hash, {})
+        for service, is_cached in service_map.items():
+            if is_cached:
+                cache_map[service] = True
+            elif service not in cache_map:
+                cache_map[service] = False
+
+
+async def _mark_scope_scraped_if_populated(media_id: str, torrents: dict) -> None:
+    if torrents:
+        await mark_scope_scraped(media_id)
+
+
+def group_debrid_entries_by_service(debrid_entries: list) -> list[tuple[str, list]]:
+    service_entries = {}
+    seen_credentials = set()
+    for entry in debrid_entries:
+        service = entry["service"]
+        credential = (service, entry["apiKey"])
+        if credential in seen_credentials:
+            continue
+        seen_credentials.add(credential)
+        service_entries.setdefault(service, []).append(entry)
+    return list(service_entries.items())
+
+
+def select_debrid_refresh_hashes(
+    current_hashes: set[str],
+    initial_hashes: set[str],
+    verified_cache_status: dict,
+    *,
+    had_cached_torrents: bool,
+    use_account_scrape: bool,
+) -> set[str]:
+    if not current_hashes:
+        return set()
+
+    verified_count = sum(
+        any(service_map.values())
+        for info_hash, service_map in verified_cache_status.items()
+        if info_hash in current_hashes
+    )
+    requires_full_refresh = (
+        (not had_cached_torrents and not use_account_scrape)
+        or verified_count == 0
+        or (verified_count / len(current_hashes)) < settings.DEBRID_CACHE_CHECK_RATIO
+    )
+    return current_hashes if requires_full_refresh else current_hashes - initial_hashes
+
+
+async def background_scrape(
+    torrent_manager: TorrentManager,
+    media_id: str,
+    debrid_entries: list,
+    ip: str,
+    session,
+):
+    scrape_lock = DistributedLock(media_id)
+    lock_acquired = await scrape_lock.acquire()
+
+    if not lock_acquired:
+        logger.log(
+            "SCRAPER",
+            f"🔒 Background scrape skipped for {media_id} - already in progress",
+        )
+        return
+
+    async def run_scrape():
+        await torrent_manager.scrape_torrents(ScrapeContext.BACKGROUND)
+
+        if debrid_entries and torrent_manager.torrents:
+            await get_and_cache_multi_service_availability(
+                session,
+                debrid_entries,
+                torrent_manager.torrents,
+                torrent_manager.media_id,
+                torrent_manager.media_only_id,
+                torrent_manager.search_season,
+                torrent_manager.search_episode,
+                torrent_manager.media_scope,
+                ip,
+                target_air_date=torrent_manager.target_air_date,
+            )
+
+    try:
+        await scrape_lock.run(run_scrape())
+        await _mark_scope_scraped_if_populated(media_id, torrent_manager.torrents)
+        logger.log("SCRAPER", f"📥 Background scrape complete for {media_id}!")
+    except Exception as exc:
+        logger.log("SCRAPER", f"❌ Background scrape failed for {media_id}: {exc}")
+    finally:
+        await scrape_lock.release()
+
+
+async def check_multi_service_availability(
+    debrid_entries: list,
+    torrents: dict,
+    season: int | None,
+    episode: int | None,
+    media_scope: MediaScope,
+):
+    service_cache_status = defaultdict(dict)
+    info_hashes = list(torrents)
+    if not info_hashes or not debrid_entries:
+        return service_cache_status
+
+    async def check_service(entry):
+        service = entry["service"]
+        debrid_instance = DebridService(service, entry["apiKey"], "")
+        cached_hashes, torrent_updates = (
+            await debrid_instance.check_existing_availability(
+                info_hashes, season, episode, media_scope, torrents
+            )
+        )
+        return service, cached_hashes, torrent_updates
+
+    service_groups = group_debrid_entries_by_service(debrid_entries)
+    results = await asyncio.gather(
+        *(check_service(entries[0]) for _, entries in service_groups),
+        return_exceptions=True,
+    )
+
+    enriched_hashes = set()
+    for result in results:
+        if isinstance(result, Exception):
+            logger.log("DEBRID", f"❌ Error checking availability: {result}")
+            continue
+        service, cached_hashes, torrent_updates = result
+        for info_hash, update in torrent_updates.items():
+            if info_hash in enriched_hashes:
+                continue
+            torrent = torrents.get(info_hash)
+            if torrent is not None:
+                torrent.update(update)
+                enriched_hashes.add(info_hash)
+        for info_hash in cached_hashes:
+            service_cache_status[info_hash][service] = True
+
+    return service_cache_status
+
+
+async def get_and_cache_multi_service_availability(
+    session,
+    debrid_entries: list,
+    torrents: dict,
+    media_id: str,
+    media_only_id: str,
+    season: int | None,
+    episode: int | None,
+    media_scope: MediaScope,
+    ip: str,
+    target_air_date: str | None = None,
+    known_cache_status: dict | None = None,
+):
+    service_cache_status = defaultdict(dict)
+    errors = {}
+    info_hashes = list(torrents)
+
+    if not info_hashes or not debrid_entries:
+        return service_cache_status, errors
+
+    seeders_map = {info_hash: torrents[info_hash]["seeders"] for info_hash in info_hashes}
+    tracker_map = {
+        info_hash: torrents[info_hash]["tracker"] for info_hash in info_hashes
+    }
+    sources_map = {
+        info_hash: torrents[info_hash]["sources"] for info_hash in info_hashes
+    }
+    service_groups = group_debrid_entries_by_service(debrid_entries)
+    known_cache_status = known_cache_status or {}
+
+    async def check_service(service, entries):
+        service_info_hashes = [
+            info_hash
+            for info_hash in info_hashes
+            if not known_cache_status.get(info_hash, {}).get(service, False)
+        ]
+        if not service_info_hashes:
+            return service, set(), {}, None
+
+        auth_error = None
+        for entry in entries:
+            try:
+                debrid_instance = DebridService(service, entry["apiKey"], ip)
+                cached_hashes, torrent_updates = (
+                    await debrid_instance.get_and_cache_availability(
+                        session,
+                        service_info_hashes,
+                        seeders_map,
+                        tracker_map,
+                        sources_map,
+                        torrents,
+                        media_id,
+                        media_only_id,
+                        season,
+                        episode,
+                        media_scope,
+                        target_air_date=target_air_date,
+                    )
+                )
+                return service, cached_hashes, torrent_updates, None
+            except DebridAuthError as error:
+                if auth_error is None:
+                    auth_error = error
+            except Exception as error:
+                return service, None, None, error
+
+        return service, None, None, auth_error
+
+    results = await asyncio.gather(
+        *(check_service(service, entries) for service, entries in service_groups),
+        return_exceptions=True,
+    )
+
+    enriched_hashes = set()
+    for result in results:
+        if isinstance(result, Exception):
+            logger.log("DEBRID", f"❌ Error checking availability: {result}")
+            continue
+
+        service, cache_map, torrent_updates, error = result
+        if error:
+            if isinstance(error, DebridAuthError):
+                errors[service] = error
+            else:
+                logger.log(
+                    "DEBRID",
+                    f"❌ Error checking availability on {service}: {error}",
+                )
+            continue
+
+        for info_hash, update in torrent_updates.items():
+            if info_hash in enriched_hashes:
+                continue
+            torrent = torrents.get(info_hash)
+            if torrent is not None:
+                torrent.update(update)
+                enriched_hashes.add(info_hash)
+
+        if cache_map:
+            for info_hash in cache_map:
+                service_cache_status[info_hash][service] = True
+
+    return service_cache_status, errors
+
+
+async def search_media(
+    media_type: str,
+    media_id: str,
+    config: Mapping[str, Any],
+    ip: str,
+    add_background_task: BackgroundTaskAdder,
+) -> MediaSearchResult:
+    if media_type not in {"movie", "series"} or "tmdb:" in media_id:
+        return MediaSearchResult(MediaSearchStatus.INVALID)
+
+    debrid_entries = config["_debridEntries"]
+    enable_torrent = config["_enableTorrent"]
+    scrape_debrid_account_torrents = config["scrapeDebridAccountTorrents"]
+    use_account_scrape = bool(debrid_entries and scrape_debrid_account_torrents)
+    is_torrent_only = enable_torrent and not debrid_entries
+
+    if settings.DISABLE_TORRENT_STREAMS and is_torrent_only:
+        return MediaSearchResult(
+            MediaSearchStatus.DISABLED,
+            is_torrent_only=is_torrent_only,
+            use_account_scrape=use_account_scrape,
+        )
+
+    session = await http_client_manager.get_session()
+    metadata_scraper = MetadataScraper(session)
+
+    try:
+        media_only_id, season, episode = parse_media_id(media_type, media_id)
+    except ValueError:
+        return MediaSearchResult(MediaSearchStatus.INVALID)
+    media_scope = resolve_media_scope(media_type, season, episode)
+
+    if settings.DIGITAL_RELEASE_FILTER:
+        is_released = await release_filter.check_is_released(
+            session, media_type, media_id, season, episode
+        )
+        if not is_released:
+            logger.log("FILTER", f"🚫 {media_id} is not released yet. Skipping.")
+            return MediaSearchResult(
+                MediaSearchStatus.UNRELEASED,
+                media_scope=media_scope,
+                media_only_id=media_only_id,
+                search_season=season,
+                search_episode=episode,
+                is_torrent_only=is_torrent_only,
+                use_account_scrape=use_account_scrape,
+            )
+
+    metadata, aliases = await metadata_scraper.fetch_metadata_and_aliases(
+        media_type, media_id, media_only_id, season, episode
+    )
+    if metadata is None:
+        logger.log("SCRAPER", f"❌ Failed to fetch metadata for {media_id}")
+        return MediaSearchResult(
+            MediaSearchStatus.METADATA_UNAVAILABLE,
+            media_scope=media_scope,
+            media_only_id=media_only_id,
+            search_season=season,
+            search_episode=episode,
+            is_torrent_only=is_torrent_only,
+            use_account_scrape=use_account_scrape,
+        )
+
+    title = metadata["title"]
+    year = metadata["year"]
+    year_end = metadata["year_end"]
+    season = metadata["season"]
+    episode = metadata["episode"]
+
+    log_title = f"({media_id}) {title}"
+    if media_type == "series" and episode is not None:
+        log_title += f" S{season:02d}E{episode:02d}"
+    logger.log("SCRAPER", f"🔍 Starting search for {log_title}")
+
+    is_kitsu = media_id.startswith("kitsu:")
+    search_episode = episode
+    search_season = season
+
+    if is_kitsu:
+        kitsu_mapping = anime_mapper.get_kitsu_episode_mapping(media_only_id)
+        if kitsu_mapping:
+            from_episode = kitsu_mapping.get("from_episode")
+            from_season = kitsu_mapping.get("from_season")
+            if from_season is not None and from_season != season:
+                search_season = from_season
+            if episode is not None and from_episode is not None:
+                new_episode = from_episode + episode - 1
+                if new_episode != episode:
+                    search_episode = new_episode
+
+            if search_season != season or search_episode != episode:
+                if episode is not None and search_season is not None:
+                    logger.log(
+                        "SCRAPER",
+                        "📺 Multi-part anime detected "
+                        f"(kitsu:{media_only_id}): searching for "
+                        f"S{search_season:02d}E{search_episode:02d} instead of "
+                        f"S{season:02d}E{episode:02d}",
+                    )
+                elif search_season is not None and season is not None:
+                    logger.log(
+                        "SCRAPER",
+                        "📺 Multi-part anime detected "
+                        f"(kitsu:{media_only_id}): searching for "
+                        f"S{search_season:02d} instead of S{season:02d}",
+                    )
+
+    cache_media_ids = [media_only_id]
+    if anime_mapper.is_loaded():
+        if is_kitsu:
+            imdb_id = await anime_mapper.get_imdb_from_kitsu(media_only_id)
+            if imdb_id:
+                cache_media_ids.append(imdb_id)
+        elif anime_mapper.is_anime_content(media_id, media_only_id):
+            kitsu_ids = anime_mapper.get_kitsu_ids_from_imdb(media_only_id)
+            if kitsu_ids:
+                cache_media_ids.extend(kitsu_ids)
+            kitsu_id = await anime_mapper.get_kitsu_from_imdb(media_only_id)
+            if kitsu_id and kitsu_id not in cache_media_ids:
+                cache_media_ids.append(kitsu_id)
+
+    is_imdb_episode_request, reject_unknown_episode_files = episode_matching_policy(
+        media_type,
+        media_only_id,
+        search_season,
+        search_episode,
+        cached_only=bool(config["cachedOnly"]),
+        has_debrid=bool(debrid_entries),
+        enable_torrent=enable_torrent,
+    )
+    target_air_date = None
+    if is_imdb_episode_request:
+        target_air_date = await EpisodeIndexService(session).get_target_air_date(
+            media_only_id,
+            search_season,
+            search_episode,
+        )
+        if target_air_date:
+            logger.log(
+                "SCRAPER",
+                f"📅 Episode target air date: {target_air_date} for "
+                f"{media_only_id} S{search_season:02d}E{search_episode:02d}",
+            )
+        else:
+            logger.log(
+                "SCRAPER",
+                f"📅 Episode target air date unavailable for {media_only_id} "
+                f"S{search_season:02d}E{search_episode:02d}",
+            )
+
+    remove_adult_content = settings.REMOVE_ADULT_CONTENT and config["removeTrash"]
+    torrent_manager = TorrentManager(
+        media_type,
+        media_id,
+        media_only_id,
+        title,
+        year,
+        year_end,
+        season,
+        episode,
+        aliases,
+        remove_adult_content,
+        is_kitsu=is_kitsu,
+        search_episode=search_episode,
+        search_season=search_season,
+        cache_media_ids=cache_media_ids,
+        target_air_date=target_air_date,
+        reject_unknown_episode_files=reject_unknown_episode_files,
+        media_scope=media_scope,
+    )
+
+    await torrent_manager.get_cached_torrents()
+    torrent_count = len(torrent_manager.torrents)
+    cache_state = "hit" if torrent_count else "miss"
+    metrics.observe_torrent_cache(media_type, cache_state, torrent_count)
+    initial_info_hashes = set(torrent_manager.torrents)
+    logger.log("SCRAPER", f"📦 Found cached torrents: {torrent_count}")
+
+    cache_manager = CacheStateManager(media_id)
+    cache_result = await cache_manager.check_and_decide(torrent_count)
+    force_scrape_now = not torrent_manager.primary_cached
+    lock_acquired = cache_result.lock_acquired
+    sort_mixed = is_torrent_only or config["sortCachedUncachedTogether"]
+    account_snapshot_ready = False
+
+    if force_scrape_now and not lock_acquired:
+        lock_acquired = await cache_manager.try_acquire_lock()
+
+    if (force_scrape_now and not lock_acquired) or (
+        cache_result.should_return_wait_message and not force_scrape_now
+    ):
+        logger.log(
+            "SCRAPER",
+            f"🔄 Another instance is scraping {log_title}, returning early",
+        )
+        return MediaSearchResult(
+            MediaSearchStatus.BUSY,
+            metadata=metadata,
+            aliases=aliases,
+            media_scope=media_scope,
+            cache_state=cache_state,
+            media_only_id=media_only_id,
+            search_season=search_season,
+            search_episode=search_episode,
+            is_torrent_only=is_torrent_only,
+            sort_mixed=sort_mixed,
+            use_account_scrape=use_account_scrape,
+        )
+
+    if cache_result.should_scrape_background and not force_scrape_now:
+        logger.log(
+            "SCRAPER",
+            f"🔄 Starting background scrape for {log_title} "
+            f"(state={cache_result.state.value})",
+        )
+        add_background_task(
+            background_scrape,
+            torrent_manager,
+            media_id,
+            debrid_entries,
+            ip,
+            session,
+        )
+
+    if cache_result.should_scrape_now or force_scrape_now:
+        logger.log("SCRAPER", f"🔎 Starting new search for {log_title}")
+        try:
+            if use_account_scrape:
+                scrape_result, warmup_result = await asyncio.gather(
+                    torrent_manager.scrape_torrents(ScrapeContext.LIVE),
+                    ensure_account_snapshot_ready(session, debrid_entries, ip),
+                    return_exceptions=True,
+                )
+                if isinstance(scrape_result, Exception):
+                    raise scrape_result
+                if isinstance(warmup_result, Exception):
+                    raise warmup_result
+                account_snapshot_ready = True
+            else:
+                await torrent_manager.scrape_torrents(ScrapeContext.LIVE)
+            await _mark_scope_scraped_if_populated(media_id, torrent_manager.torrents)
+            logger.log(
+                "SCRAPER",
+                "📥 Torrents after global RTN filtering: "
+                f"{len(torrent_manager.torrents)}",
+            )
+        finally:
+            await cache_manager.release_lock()
+
+    service_cache_status = defaultdict(dict)
+    verified_service_cache_status = defaultdict(dict)
+    if use_account_scrape:
+        if not account_snapshot_ready:
+            await ensure_account_snapshot_ready(session, debrid_entries, ip)
+        await schedule_account_snapshot_refresh(
+            add_background_task, session, debrid_entries, ip
+        )
+        account_torrents, account_cache_status = await get_account_torrents_for_media(
+            debrid_entries,
+            media_type,
+            media_scope,
+            title,
+            year,
+            year_end,
+            search_season,
+            search_episode,
+            aliases,
+            remove_adult_content,
+            target_air_date=target_air_date,
+            reject_unknown_episode_files=reject_unknown_episode_files,
+        )
+
+        for info_hash, account_torrent in account_torrents.items():
+            existing_torrent = torrent_manager.torrents.get(info_hash)
+            if existing_torrent is None:
+                torrent_manager.torrents[info_hash] = account_torrent
+                continue
+            if (
+                existing_torrent.get("fileIndex") is None
+                and account_torrent["fileIndex"] is not None
+            ):
+                existing_torrent["fileIndex"] = account_torrent["fileIndex"]
+            if (
+                existing_torrent.get("size") is None
+                and account_torrent["size"] is not None
+            ):
+                existing_torrent["size"] = account_torrent["size"]
+            existing_parsed = existing_torrent.get("parsed")
+            if existing_parsed is None or str(existing_parsed.resolution) == "unknown":
+                existing_torrent["parsed"] = account_torrent["parsed"]
+
+        if account_torrents:
+            logger.log(
+                "SCRAPER",
+                f"📚 Account scrape added {len(account_torrents)} torrents "
+                "from debrid snapshots",
+            )
+            public_cache_ingested = await ingest_account_torrents_to_public_cache(
+                account_torrents, media_only_id, search_season
+            )
+            if public_cache_ingested:
+                logger.log(
+                    "SCRAPER",
+                    f"🌐 Debrid account contributed {public_cache_ingested} rows "
+                    "to public torrent cache",
+                )
+
+        merge_service_cache_status(service_cache_status, account_cache_status)
+
+    if debrid_entries:
+        existing_service_cache_status = await check_multi_service_availability(
+            debrid_entries,
+            torrent_manager.torrents,
+            search_season,
+            search_episode,
+            media_scope,
+        )
+        merge_service_cache_status(
+            service_cache_status, existing_service_cache_status
+        )
+        merge_service_cache_status(
+            verified_service_cache_status, existing_service_cache_status
+        )
+    elif enable_torrent:
+        await DebridService.apply_cached_availability_any_service(
+            list(torrent_manager.torrents),
+            search_season,
+            search_episode,
+            media_scope,
+            torrent_manager.torrents,
+        )
+
+    current_info_hashes = set(torrent_manager.torrents)
+    debrid_refresh_hashes = select_debrid_refresh_hashes(
+        current_info_hashes,
+        initial_info_hashes,
+        verified_service_cache_status,
+        had_cached_torrents=cache_result.has_cached_torrents,
+        use_account_scrape=use_account_scrape,
+    )
+
+    debrid_errors = {}
+    if debrid_entries and debrid_refresh_hashes:
+        services_str = "+".join(entry["service"] for entry in debrid_entries)
+        logger.log(
+            "SCRAPER",
+            f"🔄 Checking availability on debrid services: {services_str} "
+            f"({len(debrid_refresh_hashes)}/{len(current_info_hashes)} torrents)",
+        )
+        torrents_to_check = {
+            info_hash: torrent
+            for info_hash, torrent in torrent_manager.torrents.items()
+            if info_hash in debrid_refresh_hashes
+        }
+        fresh_service_cache_status, debrid_errors = (
+            await get_and_cache_multi_service_availability(
+                session,
+                debrid_entries,
+                torrents_to_check,
+                media_id,
+                media_only_id,
+                search_season,
+                search_episode,
+                media_scope,
+                ip,
+                target_air_date=target_air_date,
+                known_cache_status=service_cache_status,
+            )
+        )
+        merge_service_cache_status(
+            service_cache_status, fresh_service_cache_status
+        )
+
+    for service in dict.fromkeys(entry["service"] for entry in debrid_entries):
+        cached_count = sum(
+            1
+            for cache_map in service_cache_status.values()
+            if cache_map.get(service, False)
+        )
+        logger.log(
+            "SCRAPER",
+            f"💾 Available cached torrents on {service}: "
+            f"{cached_count}/{len(torrent_manager.torrents)}",
+        )
+
+    initial_torrent_count = len(torrent_manager.torrents)
+    await torrent_manager.rank_torrents(
+        config["rtnSettings"],
+        config["rtnRanking"],
+        0,
+        config["maxSize"],
+        config["removeTrash"],
+    )
+    logger.log(
+        "SCRAPER",
+        "⚖️  Torrents after user RTN filtering: "
+        f"{len(torrent_manager.ranked_torrents)}/{initial_torrent_count}",
+    )
+
+    return MediaSearchResult(
+        MediaSearchStatus.OK,
+        metadata=metadata,
+        aliases=aliases,
+        media_scope=media_scope,
+        torrents=torrent_manager.torrents,
+        ranked_info_hashes=list(torrent_manager.ranked_torrents),
+        service_cache_status=service_cache_status,
+        debrid_errors=debrid_errors,
+        cache_state=cache_state,
+        media_only_id=media_only_id,
+        search_season=search_season,
+        search_episode=search_episode,
+        is_torrent_only=is_torrent_only,
+        sort_mixed=sort_mixed,
+        show_account_sync_trigger=use_account_scrape,
+        use_account_scrape=use_account_scrape,
+    )

--- a/comet/services/media_search.py
+++ b/comet/services/media_search.py
@@ -402,7 +402,7 @@ async def search_media(
     episode = metadata["episode"]
 
     log_title = f"({media_id}) {title}"
-    if media_type == "series" and episode is not None:
+    if media_type == "series" and season is not None and episode is not None:
         log_title += f" S{season:02d}E{episode:02d}"
     logger.log("SCRAPER", f"🔍 Starting search for {log_title}")
 

--- a/comet/services/orchestration.py
+++ b/comet/services/orchestration.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from RTN import DefaultRanking, ParsedData
 
@@ -106,6 +107,7 @@ class TorrentManager:
         self.ready_to_cache = []
         self.ranked_torrents = {}
         self.primary_cached = False
+        self.live_result_timestamp = time.time()
 
     def _matches_requested_scope(
         self,
@@ -176,6 +178,7 @@ class TorrentManager:
                 "tracker": torrent["tracker"],
                 "sources": torrent["sources"],
                 "parsed": torrent["parsed"],
+                "updatedAt": self.live_result_timestamp,
             }
 
     async def _fetch_cached_rows(self, media_id: str):
@@ -272,6 +275,7 @@ class TorrentManager:
                 "tracker": row["tracker"],
                 "sources": load_cached_string_list(row["sources_json"]),
                 "parsed": parsed_data,
+                "updatedAt": row["updated_at"],
             }
 
     def _append_cache_file_infos(self, file_infos: list[dict], torrent: dict):

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,10 @@ If you plan to use Stremio from another device/network, complete the reverse-pro
 - [CometNet Full Reference](cometnet/cometnet.md)
 - [CometNet Docker Deployment](cometnet/docker.md)
 
+## Integrations
+
+- [Torznab clients: Prowlarr, Sonarr, Radarr, and Jackett](integrations/torznab.md)
+
 ## Troubleshooting
 
 - [Troubleshooting Guide](troubleshooting.md)

--- a/docs/advanced/06-http-api-reference.md
+++ b/docs/advanced/06-http-api-reference.md
@@ -35,18 +35,8 @@ The complete endpoint is `https://host[/s/token]/torznab/api`. It exposes the
 Movies and TV categories and supports text, IMDb, season, and episode searches.
 Capabilities can be checked with `GET /torznab/api?t=caps`.
 
-For a Generic Torznab indexer in Prowlarr:
-
-- set the base URL to `https://host[/s/token]/torznab`;
-- keep the API Path as `/api`;
-- leave the API key empty.
-
-Do not include `/api` in both the base URL and API Path. Clients that request a
-single complete endpoint should use `https://host[/s/token]/torznab/api`.
-
-On a completely new instance, perform one successful media search in Comet
-before adding the indexer. This warm-up is only needed when the instance has
-never produced a real torrent result for any media.
+See the [Torznab client integration guide](../integrations/torznab.md) for the
+official Prowlarr, Sonarr, Radarr, and Jackett configurations.
 
 ## ChillLink
 

--- a/docs/advanced/06-http-api-reference.md
+++ b/docs/advanced/06-http-api-reference.md
@@ -29,6 +29,25 @@ Examples:
 - `GET /{b64config}/playback/{hash}/{service_index}/{index}/{season}/{episode}?torrent_name={torrent_name}&name={name}`
 - `GET /{b64config}/debrid-sync/{service_index}`
 
+## Torznab
+
+The complete endpoint is `https://host[/s/token]/torznab/api`. It exposes the
+Movies and TV categories and supports text, IMDb, season, and episode searches.
+Capabilities can be checked with `GET /torznab/api?t=caps`.
+
+For a Generic Torznab indexer in Prowlarr:
+
+- set the base URL to `https://host[/s/token]/torznab`;
+- keep the API Path as `/api`;
+- leave the API key empty.
+
+Do not include `/api` in both the base URL and API Path. Clients that request a
+single complete endpoint should use `https://host[/s/token]/torznab/api`.
+
+On a completely new instance, perform one successful media search in Comet
+before adding the indexer. This warm-up is only needed when the instance has
+never produced a real torrent result for any media.
+
 ## ChillLink
 
 - `GET /manifest`

--- a/docs/integrations/torznab.md
+++ b/docs/integrations/torznab.md
@@ -1,0 +1,83 @@
+# Torznab Client Integration
+
+Comet exposes a Torznab feed for Movies and TV. The complete endpoint is:
+
+```text
+https://comet.example.com[/s/<token>]/torznab/api
+```
+
+Replace the example host and optional protected prefix with values reachable
+from the client. Inside Docker, use the Comet service name and container port,
+for example `http://comet:8000/torznab/api`.
+
+Check connectivity before configuring a client:
+
+```sh
+curl --fail-with-body \
+  "https://comet.example.com/torznab/api?t=caps"
+```
+
+The response must contain the `Movies` (`2000`) and `TV` (`5000`) categories.
+On a new Comet instance, run one successful media search before the first
+indexer test.
+
+## Prowlarr
+
+Use Prowlarr's built-in **Generic Torznab** indexer. It consumes Comet directly
+and should be preferred over a custom YAML definition.
+
+| Setting | Value |
+| --- | --- |
+| Name | `Comet` |
+| URL | `https://comet.example.com[/s/<token>]/torznab` |
+| API Path | `/api` |
+| API Key | Empty |
+| Minimum Seeders | `0` |
+
+Test and save the indexer, then let Prowlarr sync it to Sonarr and Radarr. Do
+not also add Comet directly to those applications, otherwise the same releases
+can be queried twice.
+
+## Sonarr and Radarr
+
+Configure Comet directly only when Prowlarr is not managing indexers. Add a
+**Torznab** indexer with the same URL, API Path, and empty API Key used above.
+
+| Application | Categories | Minimum Seeders |
+| --- | --- | --- |
+| Sonarr | `5000 - TV` | `0` |
+| Radarr | `2000 - Movies` | `0` |
+
+Keep RSS, automatic search, and interactive search enabled. Each application
+will limit itself to the search modes and identifiers declared by Comet's
+capabilities response.
+
+## Jackett
+
+Jackett needs the bundled Cardigann definition:
+
+[`integrations/torznab/comet.yml`](../../integrations/torznab/comet.yml)
+
+1. Copy `comet.yml` into a writable Jackett definitions directory. Jackett
+   prints the active definition directories in its startup log.
+2. Restart Jackett.
+3. Add the **Comet** indexer.
+4. Set **Comet Torznab endpoint** to the complete endpoint, including `/api`
+   and the protected prefix when one is configured.
+5. Test and save the indexer.
+
+The definition forwards text, IMDb, season, episode, category, and recent-feed
+queries while preserving Comet's magnets, hashes, sizes, dates, and seeders.
+Use a direct Torznab connection or Prowlarr when possible; Jackett adds an
+extra XML parsing and serialization layer.
+
+## Troubleshooting
+
+- A connection failure usually means the client container cannot resolve or
+  reach Comet. Test the endpoint from inside that container.
+- A `Function not available` response means direct torrent streams are
+  disabled in Comet.
+- An empty test on a fresh instance usually means Comet has not completed its
+  first successful media search.
+- Keep `/api` in exactly one place: either use the complete endpoint, or split
+  it between the URL and API Path fields as shown above.

--- a/docs/integrations/torznab.md
+++ b/docs/integrations/torznab.md
@@ -10,11 +10,18 @@ Replace the example host and optional protected prefix with values reachable
 from the client. Inside Docker, use the Comet service name and container port,
 for example `http://comet:8000/torznab/api`.
 
-Check connectivity before configuring a client:
+Check connectivity before configuring a client. For an unprotected instance:
 
 ```sh
 curl --fail-with-body \
   "https://comet.example.com/torznab/api?t=caps"
+```
+
+For an instance using a protected prefix:
+
+```sh
+curl --fail-with-body \
+  "https://comet.example.com/s/<token>/torznab/api?t=caps"
 ```
 
 The response must contain the `Movies` (`2000`) and `TV` (`5000`) categories.
@@ -75,8 +82,9 @@ extra XML parsing and serialization layer.
 
 - A connection failure usually means the client container cannot resolve or
   reach Comet. Test the endpoint from inside that container.
-- A `Function not available` response means direct torrent streams are
-  disabled in Comet.
+- A `Function not available` response to `t=get` is expected because Comet
+  does not implement that function. For search requests, check `t=caps`:
+  `available="no"` means `DISABLE_TORRENT_STREAMS` is enabled.
 - An empty test on a fresh instance usually means Comet has not completed its
   first successful media search.
 - Keep `/api` in exactly one place: either use the complete endpoint, or split

--- a/integrations/torznab/comet.yml
+++ b/integrations/torznab/comet.yml
@@ -1,0 +1,83 @@
+---
+id: comet
+name: Comet
+description: "Stremio's fastest torrent/debrid search add-on."
+language: en-US
+type: public
+encoding: UTF-8
+links:
+  - http://127.0.0.1:8000/
+  - http://comet:8000/
+
+caps:
+  categorymappings:
+    - {id: 2000, cat: Movies, desc: "Movies", default: true}
+    - {id: 5000, cat: TV, desc: "TV", default: true}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
+  allowrawsearch: true
+  allowtvsearchimdb: true
+
+settings:
+  - name: endpoint
+    type: text
+    label: Comet Torznab endpoint
+    default: http://comet:8000/torznab/api
+
+login:
+  path: "{{ .Config.endpoint }}"
+  method: get
+  inputs:
+    t: caps
+
+search:
+  paths:
+    - path: "{{ .Config.endpoint }}"
+      response:
+        type: xml
+
+  inputs:
+    t: "{{ .Query.Type }}"
+    q: "{{ .Keywords }}"
+    cat: "{{ join .Categories \",\" }}"
+    imdbid: "{{ .Query.IMDBID }}"
+    season: "{{ .Query.Season }}"
+    ep: "{{ .Query.Ep }}"
+    limit: 100
+
+  rows:
+    selector: rss > channel > item
+
+  fields:
+    category:
+      selector: "[name=category]"
+      attribute: value
+    title:
+      selector: title
+    magnet:
+      selector: link
+    infohash:
+      selector: "[name=infohash]"
+      attribute: value
+    imdbid:
+      selector: "[name=imdb]"
+      attribute: value
+    date:
+      selector: pubDate
+    size:
+      selector: size
+    seeders:
+      selector: "[name=seeders]"
+      attribute: value
+      optional: true
+      default: 0
+    leechers:
+      text: 0
+    downloadvolumefactor:
+      text: 0
+    uploadvolumefactor:
+      text: 1
+# torznab xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
 [tool.uv.sources]
 torrent-parse-rank = { git = "https://github.com/g0ldyy/torrent-parse-rank" }
 
+[dependency-groups]
+dev = ["pytest>=7.0"]
+
 [tool.ruff.lint]
 # Broad exception handling is intentional at task, network, and plugin boundaries.
 # ValueError is also part of the validation contract for malformed external data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ ignore = ["BLE001", "S110", "S112", "SIM117", "TRY004"]
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Depends"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_episode_index.py
+++ b/tests/test_episode_index.py
@@ -1,6 +1,6 @@
 import unittest
 from contextlib import asynccontextmanager
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from comet.metadata.episode_index import EpisodeIndexService, database
 
@@ -29,6 +29,33 @@ class EpisodeIndexRefreshTests(unittest.IsolatedAsyncioTestCase):
                 patch.object(database, "fetch_val", return_value=value),
             ):
                 self.assertFalse(await service._is_series_index_fresh("tt123", 1.0))
+
+    async def test_air_date_reverse_lookup_refreshes_the_existing_index_once(self):
+        service = EpisodeIndexService(session=None)
+        with (
+            patch.object(
+                service,
+                "_get_cached_episode",
+                new=AsyncMock(side_effect=[None, (3, 9)]),
+            ) as cached_lookup,
+            patch.object(
+                service,
+                "_is_series_index_fresh",
+                new=AsyncMock(return_value=False),
+            ),
+            patch.object(
+                service,
+                "_refresh_from_cinemeta",
+                new=AsyncMock(),
+            ) as refresh,
+        ):
+            episode = await service.get_episode_by_air_date(
+                "tt1234567", "2026-07-25"
+            )
+
+        self.assertEqual(episode, (3, 9))
+        self.assertEqual(cached_lookup.await_count, 2)
+        refresh.assert_awaited_once_with("tt1234567")
 
     async def test_rows_and_refresh_marker_share_one_transaction(self):
         service = EpisodeIndexService(session=None)

--- a/tests/test_multi_service_debrid.py
+++ b/tests/test_multi_service_debrid.py
@@ -3,10 +3,10 @@ import unittest
 from typing import ClassVar
 from unittest.mock import patch
 
-from comet.api.endpoints.stream import (
-    _select_debrid_refresh_hashes,
+from comet.services.media_search import (
     check_multi_service_availability,
     get_and_cache_multi_service_availability,
+    select_debrid_refresh_hashes,
 )
 from comet.debrid.exceptions import DebridAuthError
 from comet.utils.parsing import MediaScope
@@ -71,10 +71,10 @@ class MultiServiceDebridTests(unittest.IsolatedAsyncioTestCase):
         new_hash = "b" * 40
 
         with patch(
-            "comet.api.endpoints.stream.settings.DEBRID_CACHE_CHECK_RATIO",
+            "comet.services.media_search.settings.DEBRID_CACHE_CHECK_RATIO",
             0.0,
         ):
-            selected = _select_debrid_refresh_hashes(
+            selected = select_debrid_refresh_hashes(
                 {old_hash, new_hash},
                 {old_hash},
                 {old_hash: {"torbox": True}},
@@ -103,7 +103,7 @@ class MultiServiceDebridTests(unittest.IsolatedAsyncioTestCase):
         _SelectiveDebridService.checked_hashes = {}
 
         with patch(
-            "comet.api.endpoints.stream.DebridService",
+            "comet.services.media_search.DebridService",
             new=_SelectiveDebridService,
         ):
             await get_and_cache_multi_service_availability(
@@ -134,7 +134,7 @@ class MultiServiceDebridTests(unittest.IsolatedAsyncioTestCase):
         ]
 
         with patch(
-            "comet.api.endpoints.stream.DebridService",
+            "comet.services.media_search.DebridService",
             new=_DebridService,
         ):
             status = await check_multi_service_availability(
@@ -161,7 +161,7 @@ class MultiServiceDebridTests(unittest.IsolatedAsyncioTestCase):
         ]
 
         with patch(
-            "comet.api.endpoints.stream.DebridService",
+            "comet.services.media_search.DebridService",
             new=_DebridService,
         ):
             status, errors = await get_and_cache_multi_service_availability(
@@ -199,7 +199,7 @@ class MultiServiceDebridTests(unittest.IsolatedAsyncioTestCase):
         _CredentialDebridService.attempts = []
 
         with patch(
-            "comet.api.endpoints.stream.DebridService",
+            "comet.services.media_search.DebridService",
             new=_CredentialDebridService,
         ):
             status, errors = await get_and_cache_multi_service_availability(

--- a/tests/test_stream_scrape_context.py
+++ b/tests/test_stream_scrape_context.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest.mock import AsyncMock, patch
 
-from comet.api.endpoints.stream import background_scrape
 from comet.core.scrape import ScrapeContext
+from comet.services.media_search import background_scrape
 
 
 class StreamScrapeContextTests(unittest.IsolatedAsyncioTestCase):
@@ -19,11 +19,11 @@ class StreamScrapeContextTests(unittest.IsolatedAsyncioTestCase):
 
         with (
             patch(
-                "comet.api.endpoints.stream.DistributedLock",
+                "comet.services.media_search.DistributedLock",
                 return_value=lock,
             ),
             patch(
-                "comet.api.endpoints.stream.mark_scope_scraped",
+                "comet.services.media_search.mark_scope_scraped",
                 new=AsyncMock(),
             ) as mark_scraped,
         ):
@@ -52,11 +52,11 @@ class StreamScrapeContextTests(unittest.IsolatedAsyncioTestCase):
 
         with (
             patch(
-                "comet.api.endpoints.stream.DistributedLock",
+                "comet.services.media_search.DistributedLock",
                 return_value=lock,
             ),
             patch(
-                "comet.api.endpoints.stream.mark_scope_scraped",
+                "comet.services.media_search.mark_scope_scraped",
                 new=AsyncMock(),
             ) as mark_scraped,
         ):

--- a/tests/test_torznab.py
+++ b/tests/test_torznab.py
@@ -249,6 +249,17 @@ class TorznabPureTests(unittest.IsolatedAsyncioTestCase):
             )
         )
 
+        nearby_session = _Session(
+            _Response(
+                {"d": [{"id": "tt2222222", "qid": "tvSeries", "y": 2025}]}
+            )
+        )
+        nearby_match = await resolve_imdb_title(
+            nearby_session, "A title", media_type="series", year=2026
+        )
+        self.assertEqual(nearby_match.imdb_id, "tt2222222")
+        self.assertEqual(nearby_match.year, 2025)
+
     async def test_recent_selection_requires_real_rows_and_bounds_type_lookup(self):
         rows = [
             {"media_id": "kitsu:123"},
@@ -314,13 +325,14 @@ class TorznabPureTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(attrs["infohash"], info_hash)
         self.assertEqual(attrs["imdb"], "1234567")
         self.assertEqual(attrs["seeders"], "0")
-        self.assertIn("magnet:?xt=urn%3Abtih%3A", attrs["magneturl"])
+        self.assertIn("magnet:?xt=urn:btih:", attrs["magneturl"])
         self.assertEqual(attrs["magneturl"].count("tr="), 1)
 
     def test_magnet_encodes_title_and_normalizes_trackers(self):
         torrent = _torrent(0, title="A & B")
         magnet = build_magnet("a" * 40, "A & B", torrent)
 
+        self.assertTrue(magnet.startswith(f"magnet:?xt=urn:btih:{'a' * 40}&"))
         self.assertIn("dn=A%20%26%20B", magnet)
         self.assertEqual(magnet.count("tr="), 1)
         self.assertNotIn("dht", magnet)
@@ -344,6 +356,23 @@ class TorznabPureTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual([len(page) for page in pages], [100, 100, 5, 0])
         self.assertEqual(len(set().union(*map(set, pages))), 205)
+
+    def test_pagination_only_serializes_the_requested_window(self):
+        result = _result(205)
+        with patch(
+            "comet.api.endpoints.torznab.build_magnet",
+            wraps=build_magnet,
+        ) as magnet_builder:
+            _, total, count = serialize_feed(
+                result,
+                "movie",
+                100,
+                100,
+                "https://example.test/torznab/api",
+            )
+
+        self.assertEqual((total, count), (205, 100))
+        self.assertEqual(magnet_builder.call_count, 100)
 
 
 class TorznabRouteTests(unittest.IsolatedAsyncioTestCase):
@@ -495,16 +524,9 @@ class TorznabRouteTests(unittest.IsolatedAsyncioTestCase):
 
     def test_route_is_mounted_only_under_the_configured_prefix(self):
         from comet.api.app import app
-        from comet.api.endpoints.torznab import router
 
         expected = f"{settings.STREMIO_API_PREFIX}/torznab/api"
-        mounted = []
-        for included in app.routes:
-            if getattr(included, "original_router", None) is not router:
-                continue
-            prefix = included.include_context.prefix
-            mounted.extend(prefix + route.path for route in router.routes)
-        self.assertEqual(mounted, [expected])
+        self.assertEqual(str(app.url_path_for("torznab_api")), expected)
 
     async def test_stream_adapter_preserves_shared_ranked_order(self):
         from comet.api.endpoints import stream as stream_endpoint

--- a/tests/test_torznab.py
+++ b/tests/test_torznab.py
@@ -1,0 +1,542 @@
+import unittest
+import xml.etree.ElementTree as ET
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import BackgroundTasks
+from RTN import ParsedData
+from starlette.requests import Request
+
+from comet.api.endpoints.torznab import (
+    NEWZNAB_NAMESPACE,
+    TORZNAB_NAMESPACE,
+    CategoryConstraint,
+    SearchTarget,
+    TorznabProtocolError,
+    build_magnet,
+    category_constraint,
+    find_recent_target,
+    parse_torznab_query,
+    resolve_search_target,
+    serialize_caps,
+    serialize_feed,
+    torznab_api,
+)
+from comet.core.models import settings
+from comet.metadata.imdb import resolve_imdb_title
+from comet.services.media_search import MediaSearchResult, MediaSearchStatus
+
+
+def _request(query: str = "", path: str = "/torznab/api") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "https",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": query.encode(),
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("example.test", 443),
+        }
+    )
+
+
+def _torrent(index: int, *, title: str | None = None, seeders: int = 0) -> dict:
+    release_title = title if title is not None else f"Movie.Release.{index}"
+    return {
+        "title": release_title,
+        "seeders": seeders,
+        "size": index + 1,
+        "tracker": "indexer",
+        "sources": [
+            "tracker:udp://tracker.example:80/announce",
+            "udp://tracker.example:80/announce",
+            "dht:node",
+        ],
+        "updatedAt": 1_700_000_000,
+        "parsed": ParsedData(
+            raw_title=release_title,
+            resolution="1080p",
+            year=2024,
+            languages=["en"],
+        ),
+    }
+
+
+def _result(count: int, *, media_type: str = "movie") -> MediaSearchResult:
+    hashes = [f"{index:040x}" for index in range(count)]
+    return MediaSearchResult(
+        MediaSearchStatus.OK,
+        metadata={"title": "Movie", "year": 2024},
+        torrents={
+            info_hash: _torrent(index) for index, info_hash in enumerate(hashes)
+        },
+        ranked_info_hashes=hashes,
+        media_only_id="tt1234567",
+        search_season=0 if media_type == "series" else None,
+        search_episode=2 if media_type == "series" else None,
+    )
+
+
+class _Response:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def json(self):
+        return self.payload
+
+
+class _Session:
+    def __init__(self, response):
+        self.response = response
+        self.requests = []
+
+    def get(self, url):
+        self.requests.append(url)
+        return self.response
+
+
+class TorznabPureTests(unittest.IsolatedAsyncioTestCase):
+    def test_caps_are_parseable_and_honest(self):
+        with patch.object(settings, "DISABLE_TORRENT_STREAMS", False):
+            root = ET.fromstring(serialize_caps())
+
+        self.assertEqual(root.tag, "caps")
+        self.assertEqual(root.find("server").attrib["version"], "1.3")
+        self.assertEqual(root.find("limits").attrib, {"max": "100", "default": "100"})
+        self.assertEqual(
+            [category.attrib["id"] for category in root.findall("categories/category")],
+            ["2000", "5000"],
+        )
+        self.assertTrue(
+            all(
+                node.attrib["available"] == "yes"
+                for node in root.findall("searching/*")
+            )
+        )
+
+        with patch.object(settings, "DISABLE_TORRENT_STREAMS", True):
+            disabled = ET.fromstring(serialize_caps())
+        self.assertTrue(
+            all(
+                node.attrib["available"] == "no"
+                for node in disabled.findall("searching/*")
+            )
+        )
+
+    def test_manual_parser_handles_case_repetition_and_scopes(self):
+        parsed = parse_torznab_query(
+            _request(
+                "T=TVSEARCH&Q=Ignored&IMDBID=1234567"
+                "&CAT=5000,5030&cat=5040&season=S0&ep=E2"
+                "&offset=100&limit=999&O=XML"
+            )
+        )
+
+        self.assertEqual(parsed.function, "tvsearch")
+        self.assertEqual(parsed.imdb_id, "tt1234567")
+        self.assertEqual(parsed.categories, (5000, 5030, 5040))
+        self.assertEqual((parsed.season, parsed.episode), (0, 2))
+        self.assertEqual((parsed.offset, parsed.limit), (100, 100))
+
+        daily = parse_torznab_query(
+            _request("t=tvsearch&q=Daily.Show&season=2026&ep=07/25")
+        )
+        self.assertEqual((daily.season, daily.episode), (2026, "07/25"))
+
+    def test_parser_rejects_invalid_values_with_protocol_errors(self):
+        invalid_queries = (
+            "t=caps&o=json",
+            "t=search&cat=-1",
+            "t=search&offset=-1",
+            "t=search&limit=no",
+            "t=search&season=one",
+            "t=search&ep=E",
+            "t=tvsearch&q=Show&season=2026&ep=13/40",
+            "t=tvsearch&q=Show&season=13&ep=07/25",
+            "t=search&year=24",
+            "t=search&o=json",
+        )
+        for query in invalid_queries:
+            with self.subTest(query=query), self.assertRaises(
+                TorznabProtocolError
+            ) as context:
+                parse_torznab_query(_request(query))
+            self.assertEqual(context.exception.code, 201)
+
+    async def test_title_scope_and_daily_episode_resolve_canonical_ids(self):
+        session = object()
+        title_match = SimpleNamespace(
+            imdb_id="tt7654321", media_type="series", year=2024
+        )
+        parsed = parse_torznab_query(
+            _request("t=search&q=Show.Name.S01E002&cat=5000")
+        )
+        with patch(
+            "comet.api.endpoints.torznab.resolve_imdb_title",
+            new=AsyncMock(return_value=title_match),
+        ) as resolver:
+            target = await resolve_search_target(
+                parsed, category_constraint(parsed.categories), session
+            )
+
+        self.assertEqual(target, SearchTarget("series", "tt7654321:1:2"))
+        resolver.assert_awaited_once_with(
+            session, "Show.Name", media_type="series", year=None
+        )
+
+        daily = parse_torznab_query(
+            _request("t=tvsearch&imdbid=7654321&season=2026&ep=07/25")
+        )
+        with patch(
+            "comet.api.endpoints.torznab.EpisodeIndexService.get_episode_by_air_date",
+            new=AsyncMock(return_value=(3, 9)),
+        ) as episode_lookup:
+            target = await resolve_search_target(
+                daily, CategoryConstraint(None, False), session
+            )
+        self.assertEqual(target, SearchTarget("series", "tt7654321:3:9"))
+        episode_lookup.assert_awaited_once_with("tt7654321", "2026-07-25")
+
+        prioritized = parse_torznab_query(
+            _request(
+                "t=search&imdbid=1234567&q=Different.Show.S01E02&cat=5000"
+            )
+        )
+        target = await resolve_search_target(
+            prioritized, category_constraint(prioritized.categories), session
+        )
+        self.assertEqual(target, SearchTarget("series", "tt1234567:1:2"))
+
+    async def test_title_resolver_uses_one_request_and_filters_type_and_year(self):
+        session = _Session(
+            _Response(
+                {
+                    "d": [
+                        {"id": "tt1111111", "qid": "movie", "y": 2024},
+                        {"id": "bad", "qid": "tvSeries", "y": 2026},
+                        {"id": "tt2222222", "qid": "tvSeries", "y": 2025},
+                        {"id": "tt3333333", "qid": "tvSeries", "y": 2026},
+                    ]
+                }
+            )
+        )
+
+        match = await resolve_imdb_title(
+            session, "A title", media_type="series", year=2026
+        )
+
+        self.assertEqual(match.imdb_id, "tt3333333")
+        self.assertEqual(match.media_type, "series")
+        self.assertEqual(len(session.requests), 1)
+
+        no_match_session = _Session(
+            _Response({"d": [{"id": "tt1111111", "qid": "movie", "y": 2024}]})
+        )
+        self.assertIsNone(
+            await resolve_imdb_title(
+                no_match_session, "A title", media_type="series", year=2026
+            )
+        )
+
+    async def test_recent_selection_requires_real_rows_and_bounds_type_lookup(self):
+        rows = [
+            {"media_id": "kitsu:123"},
+            {"media_id": "tt1111111"},
+            {"media_id": "tt2222222"},
+        ]
+        with (
+            patch(
+                "comet.api.endpoints.torznab.database.fetch_all",
+                new=AsyncMock(return_value=rows),
+            ),
+            patch(
+                "comet.api.endpoints.torznab._candidate_torrent_row",
+                new=AsyncMock(
+                    side_effect=[
+                        {"season": None, "episode": None},
+                        {"season": None, "episode": None},
+                    ]
+                ),
+            ),
+            patch(
+                "comet.api.endpoints.torznab.TMDBApi.get_media_type_from_imdb",
+                new=AsyncMock(return_value=None),
+            ) as media_type_lookup,
+        ):
+            target = await find_recent_target(
+                CategoryConstraint(None, False), object()
+            )
+
+        self.assertIsNone(target)
+        media_type_lookup.assert_awaited_once_with("tt1111111")
+
+    def test_xml_serialization_sanitizes_and_emits_required_fields(self):
+        result = _result(1)
+        info_hash = result.ranked_info_hashes[0]
+        result.torrents[info_hash] = _torrent(
+            0, title="A & B < C\x00 😀", seeders=0
+        )
+
+        content, total, count = serialize_feed(
+            result,
+            "movie",
+            0,
+            100,
+            "https://example.test/torznab/api?a=1&b=2",
+            request_timestamp=1_700_000_001,
+        )
+        root = ET.fromstring(content)
+        item = root.find("channel/item")
+        attrs = {
+            element.attrib["name"]: element.attrib["value"]
+            for element in item.findall(f"{{{TORZNAB_NAMESPACE}}}attr")
+        }
+
+        self.assertEqual((total, count), (1, 1))
+        self.assertIn(b'xmlns:torznab="http://torznab.com/', content)
+        self.assertIn(b'xmlns:newznab="http://www.newznab.com/', content)
+        self.assertEqual(item.findtext("title"), "A & B < C 😀")
+        self.assertIsNotNone(item.find("pubDate"))
+        self.assertEqual(item.findtext("category"), "Movies")
+        self.assertEqual(item.findtext("size"), "1")
+        self.assertEqual(item.find("enclosure").attrib["length"], "1")
+        self.assertEqual(attrs["infohash"], info_hash)
+        self.assertEqual(attrs["imdb"], "1234567")
+        self.assertEqual(attrs["seeders"], "0")
+        self.assertIn("magnet:?xt=urn%3Abtih%3A", attrs["magneturl"])
+        self.assertEqual(attrs["magneturl"].count("tr="), 1)
+
+    def test_magnet_encodes_title_and_normalizes_trackers(self):
+        torrent = _torrent(0, title="A & B")
+        magnet = build_magnet("a" * 40, "A & B", torrent)
+
+        self.assertIn("dn=A%20%26%20B", magnet)
+        self.assertEqual(magnet.count("tr="), 1)
+        self.assertNotIn("dht", magnet)
+
+    def test_pagination_uses_ranked_serializable_total_without_overlap(self):
+        result = _result(205)
+        pages = []
+        for offset in (0, 100, 200, 300):
+            content, total, count = serialize_feed(
+                result, "movie", offset, 100, "https://example.test/torznab/api"
+            )
+            root = ET.fromstring(content)
+            response = root.find(f"channel/{{{NEWZNAB_NAMESPACE}}}response")
+            hashes = [
+                item.findtext("guid") for item in root.findall("channel/item")
+            ]
+            self.assertEqual(int(response.attrib["total"]), 205)
+            self.assertEqual(total, 205)
+            self.assertEqual(len(hashes), count)
+            pages.append(hashes)
+
+        self.assertEqual([len(page) for page in pages], [100, 100, 5, 0])
+        self.assertEqual(len(set().union(*map(set, pages))), 205)
+
+
+class TorznabRouteTests(unittest.IsolatedAsyncioTestCase):
+    async def test_category_filter_returns_empty_before_search(self):
+        request = _request("t=movie&imdbid=1234567&cat=5000")
+        with patch(
+            "comet.api.endpoints.torznab.search_media", new=AsyncMock()
+        ) as search:
+            response = await torznab_api(request, BackgroundTasks())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers["content-type"],
+            "application/rss+xml; charset=utf-8",
+        )
+        self.assertEqual(
+            ET.fromstring(response.body)
+            .find(f"channel/{{{NEWZNAB_NAMESPACE}}}response")
+            .attrib["total"],
+            "0",
+        )
+        search.assert_not_awaited()
+
+    async def test_unknown_categories_return_empty_before_search(self):
+        request = _request("t=search&q=Movie&cat=1000,7000")
+        with patch(
+            "comet.api.endpoints.torznab.search_media", new=AsyncMock()
+        ) as search:
+            response = await torznab_api(request, BackgroundTasks())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ET.fromstring(response.body).tag, "rss")
+        search.assert_not_awaited()
+
+    async def test_targeted_search_uses_exact_default_config_object(self):
+        request = _request("t=movie&imdbid=1234567")
+        config = object()
+        result = _result(1)
+        session = object()
+        with (
+            patch(
+                "comet.api.endpoints.torznab.http_client_manager.get_session",
+                new=AsyncMock(return_value=session),
+            ),
+            patch(
+                "comet.api.endpoints.torznab.config_check",
+                return_value=config,
+            ) as check,
+            patch(
+                "comet.api.endpoints.torznab.search_media",
+                new=AsyncMock(return_value=result),
+            ) as search,
+        ):
+            response = await torznab_api(request, BackgroundTasks())
+
+        self.assertEqual(response.status_code, 200)
+        check.assert_called_once_with(None, strict_b64config=True)
+        self.assertIs(search.await_args.args[2], config)
+        self.assertEqual(search.await_args.args[:2], ("movie", "tt1234567"))
+
+    async def test_recent_probe_selects_one_target_and_calls_search_once(self):
+        request = _request("t=search")
+        target = SearchTarget("series", "tt1234567:1:2")
+        with (
+            patch(
+                "comet.api.endpoints.torznab.http_client_manager.get_session",
+                new=AsyncMock(return_value=object()),
+            ),
+            patch(
+                "comet.api.endpoints.torznab.find_recent_target",
+                new=AsyncMock(return_value=target),
+            ) as recent,
+            patch(
+                "comet.api.endpoints.torznab.config_check",
+                return_value={},
+            ),
+            patch(
+                "comet.api.endpoints.torznab.search_media",
+                new=AsyncMock(return_value=_result(1, media_type="series")),
+            ) as search,
+        ):
+            response = await torznab_api(request, BackgroundTasks())
+
+        self.assertEqual(response.status_code, 200)
+        recent.assert_awaited_once()
+        search.assert_awaited_once()
+
+    async def test_empty_recent_probe_is_an_honest_empty_feed(self):
+        request = _request("t=search")
+        with (
+            patch(
+                "comet.api.endpoints.torznab.http_client_manager.get_session",
+                new=AsyncMock(return_value=object()),
+            ),
+            patch(
+                "comet.api.endpoints.torznab.find_recent_target",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "comet.api.endpoints.torznab.search_media",
+                new=AsyncMock(),
+            ) as search,
+        ):
+            response = await torznab_api(request, BackgroundTasks())
+
+        root = ET.fromstring(response.body)
+        self.assertEqual(
+            root.find(f"channel/{{{NEWZNAB_NAMESPACE}}}response").attrib["total"],
+            "0",
+        )
+        search.assert_not_awaited()
+
+    async def test_errors_are_xml_http_200_and_do_not_leak_exceptions(self):
+        invalid = await torznab_api(
+            _request("t=tvsearch&q=Show&ep=2"), BackgroundTasks()
+        )
+        self.assertEqual(invalid.status_code, 200)
+        self.assertEqual(ET.fromstring(invalid.body).attrib["code"], "201")
+
+        request = _request("t=movie&imdbid=1234567")
+        with (
+            patch.object(settings, "HTTP_CACHE_ENABLED", True),
+            patch(
+                "comet.api.endpoints.torznab.http_client_manager.get_session",
+                new=AsyncMock(return_value=object()),
+            ),
+            patch(
+                "comet.api.endpoints.torznab.config_check",
+                return_value={},
+            ),
+            patch(
+                "comet.api.endpoints.torznab.search_media",
+                new=AsyncMock(side_effect=RuntimeError("private detail")),
+            ),
+        ):
+            backend = await torznab_api(request, BackgroundTasks())
+
+        root = ET.fromstring(backend.body)
+        self.assertEqual(root.attrib["code"], "900")
+        self.assertNotIn(b"private detail", backend.body)
+        self.assertIn("no-store", backend.headers.get("cache-control", ""))
+
+    async def test_global_disable_returns_unavailable_xml(self):
+        with patch.object(settings, "DISABLE_TORRENT_STREAMS", True):
+            response = await torznab_api(
+                _request("t=search&q=Movie"), BackgroundTasks()
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ET.fromstring(response.body).attrib["code"], "203")
+
+    def test_route_is_mounted_only_under_the_configured_prefix(self):
+        from comet.api.app import app
+        from comet.api.endpoints.torznab import router
+
+        expected = f"{settings.STREMIO_API_PREFIX}/torznab/api"
+        mounted = []
+        for included in app.routes:
+            if getattr(included, "original_router", None) is not router:
+                continue
+            prefix = included.include_context.prefix
+            mounted.extend(prefix + route.path for route in router.routes)
+        self.assertEqual(mounted, [expected])
+
+    async def test_stream_adapter_preserves_shared_ranked_order(self):
+        from comet.api.endpoints import stream as stream_endpoint
+        from comet.api.endpoints import torznab as torznab_endpoint
+        from comet.core.config_validation import config_check
+
+        self.assertIs(stream_endpoint.search_media, torznab_endpoint.search_media)
+        config = config_check(None, strict_b64config=True)
+        result = _result(3)
+        result.sort_mixed = True
+        with (
+            patch.object(settings, "HTTP_CACHE_ENABLED", False),
+            patch.object(stream_endpoint, "config_check", return_value=config),
+            patch.object(
+                stream_endpoint,
+                "search_media",
+                new=AsyncMock(return_value=result),
+            ) as search,
+        ):
+            response = await stream_endpoint.stream(
+                _request(path="/stream/movie/tt1234567.json"),
+                "movie",
+                "tt1234567",
+                BackgroundTasks(),
+            )
+
+        self.assertIs(search.await_args.args[2], config)
+        self.assertEqual(
+            [stream["infoHash"] for stream in response["streams"]],
+            result.ranked_info_hashes,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,11 @@ dependencies = [
     { name = "xxhash" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiofiles" },
@@ -413,6 +418,9 @@ requires-dist = [
     { name = "websockets" },
     { name = "xxhash" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=7.0" }]
 
 [[package]]
 name = "cryptography"
@@ -720,6 +728,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1092,6 +1109,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1336,6 +1362,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- share the media search pipeline with existing stream routes
- support capabilities, movie, series, title, and IMDb searches
- add safe RSS serialization, pagination, recent probes, and HTTP caching
- document client configuration and add comprehensive tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full Torznab/Newznab API support for Movies and TV (`/torznab/api`), including `t=caps`, RSS feeds, magnet/infohash output, pagination, and Torznab-style protocol error responses.
  * Added IMDb title resolution plus TV daily episode (air-date) lookup for more accurate TV matching.
* **Improvements**
  * Stream responses now more reliably short-circuit with empty/warned output for invalid/disabled/unreleased/metadata-unavailable/busy cases.
  * Improved torrent freshness tracking and multi-service debrid availability behavior.
* **Documentation**
  * Added a Torznab integration guide, updated the HTTP API reference, and documented the new integration.
* **Tests**
  * Expanded Torznab, IMDb/air-date, episode-index, and multi-service debrid coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->