### PR TITLE
fix: normalize null rank threshold option

### DIFF
--- a/comet/core/config_validation.py
+++ b/comet/core/config_validation.py
@@ -62,9 +62,14 @@ def _parse_and_validate_config(b64config: str):
         validated_config = ConfigModel(**config)
         validated_config = validated_config.model_dump()
 
-        options = validated_config["options"]
+        default_options = rtn_settings_default_dumped["options"]
+        options = {**default_options, **(validated_config["options"] or {})}
+        remove_ranks_under = options.get("remove_ranks_under")
+        if not isinstance(remove_ranks_under, int | float):
+            remove_ranks_under = default_options["remove_ranks_under"]
+
         validated_config["options"] = {
-            "remove_ranks_under": options["remove_ranks_under"],
+            "remove_ranks_under": remove_ranks_under,
             "allow_english_in_languages": options["allow_english_in_languages"],
             "remove_unknown_languages": options["remove_unknown_languages"],
             "remove_all_trash": validated_config["removeTrash"],

--- a/tests/test_config_compatibility.py
+++ b/tests/test_config_compatibility.py
@@ -26,6 +26,23 @@ class LegacyDebridConfigTests(unittest.TestCase):
         )
         self.assertFalse(config["_enableTorrent"])
 
+    def test_null_remove_ranks_under_uses_default_threshold(self):
+        encoded = base64.b64encode(
+            orjson.dumps(
+                {
+                    "options": {
+                        "remove_ranks_under": None,
+                    },
+                }
+            )
+        ).decode()
+
+        config = config_check(encoded, strict_b64config=True)
+
+        self.assertIsNotNone(config)
+        self.assertIsInstance(config["options"]["remove_ranks_under"], int)
+        self.assertIsInstance(config["rtnSettings"].options["remove_ranks_under"], int)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi! This is a small compatibility fix for configs that include `options.remove_ranks_under` as `null`.

## Summary
- Merge provided config options with the default RTN options before building `rtnSettings`.
- Fall back to the default rank threshold when `remove_ranks_under` is null or otherwise non-numeric.
- Add a focused regression test for the null threshold case.

## Why
This keeps older or hand-edited configurations from reaching ranking with a `None` threshold, where integer rank comparisons can fail.

## Test plan
- `python3 -m compileall -q comet tests/test_config_compatibility.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation when the rank-removal threshold is missing or invalid.
  * Invalid or null threshold values now safely use the default setting.
  * Ensured the corrected value is consistently applied throughout the resulting configuration.

* **Tests**
  * Added compatibility coverage confirming default threshold behavior for null configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->