### PR TITLE
fix(cache): revalidate cached torrent titles

### DIFF
--- a/comet/services/filtering.py
+++ b/comet/services/filtering.py
@@ -73,7 +73,7 @@ def alternate_title_match(torrent_title: str, title: str, aliases) -> bool:
             continue
 
         try:
-            parsed_segment = _parse_with_cache(segment)
+            parsed_segment = parse_with_cache(segment)
         except ValidationError:
             continue
 
@@ -208,7 +208,7 @@ def _clone_parsed(parsed):
     return clone
 
 
-def _parse_with_cache(title: str):
+def parse_with_cache(title: str):
     if _PARSE_CACHE_SIZE <= 0 or _PARSE_CACHE_EFFECTIVE_SHARDS <= 0:
         return parse(title)
 
@@ -342,7 +342,7 @@ def filter_worker(
 
         # temp fix while waiting for RTN to fix their parsing
         try:
-            parsed = _parse_with_cache(torrent_title)
+            parsed = parse_with_cache(torrent_title)
         except ValidationError:
             _log_exclusion(f"❌ Rejected (Parse Error) | {torrent_title}")
             continue

--- a/comet/services/orchestration.py
+++ b/comet/services/orchestration.py
@@ -9,7 +9,7 @@ from comet.core.models import CometSettingsModel, database, settings
 from comet.core.scrape import ScrapeContext
 from comet.scrapers.manager import scraper_manager
 from comet.scrapers.models import ScrapeRequest
-from comet.services.filtering import filter_worker
+from comet.services.filtering import TitleMatcher, filter_worker
 from comet.services.ranking import rank_worker
 from comet.services.torrent_manager import torrent_update_queue
 from comet.utils.languages import select_indexer_titles
@@ -196,6 +196,7 @@ class TorrentManager:
 
     async def get_cached_torrents(self):
         rows = []
+        primary_info_hashes = set()
         cache_row_groups = await asyncio.gather(
             *(
                 self._fetch_cached_rows(cache_media_id)
@@ -203,8 +204,8 @@ class TorrentManager:
             )
         )
         for cache_media_id, cache_rows in zip(self.cache_media_ids, cache_row_groups):
-            if cache_rows and cache_media_id == self.media_only_id:
-                self.primary_cached = True
+            if cache_media_id == self.media_only_id:
+                primary_info_hashes.update(row["info_hash"] for row in cache_rows)
             rows.extend(cache_rows)
 
         if rows:
@@ -237,6 +238,14 @@ class TorrentManager:
 
             rows = list(best_rows.values())
 
+        title_matcher = TitleMatcher(
+            self.title,
+            self.year,
+            self.year_end,
+            self.media_type,
+            self.aliases,
+        )
+
         for row in rows:
             parsed_data = load_cached_parsed(row["parsed_json"])
             if parsed_data is None:
@@ -245,6 +254,11 @@ class TorrentManager:
                 )
                 continue
             ensure_multi_language(parsed_data)
+
+            if parsed_data.parsed_title and not title_matcher.matches(
+                row["title"], parsed_data.parsed_title, parsed_data.year
+            ):
+                continue
 
             target_season = self.search_season
             if (
@@ -277,6 +291,8 @@ class TorrentManager:
                 "parsed": parsed_data,
                 "updatedAt": row["updated_at"],
             }
+            if info_hash in primary_info_hashes:
+                self.primary_cached = True
 
     def _append_cache_file_infos(self, file_infos: list[dict], torrent: dict):
         parsed = torrent["parsed"]

--- a/comet/services/orchestration.py
+++ b/comet/services/orchestration.py
@@ -197,17 +197,16 @@ class TorrentManager:
 
     async def get_cached_torrents(self):
         rows = []
-        primary_info_hashes = set()
         cache_row_groups = await asyncio.gather(
             *(
                 self._fetch_cached_rows(cache_media_id)
                 for cache_media_id in self.cache_media_ids
             )
         )
-        for cache_media_id, cache_rows in zip(self.cache_media_ids, cache_row_groups):
-            if cache_media_id == self.media_only_id:
-                primary_info_hashes.update(row["info_hash"] for row in cache_rows)
-            rows.extend(cache_rows)
+        for cache_media_id, cache_rows in zip(
+            self.cache_media_ids, cache_row_groups, strict=True
+        ):
+            rows.extend((cache_media_id, row) for row in cache_rows)
 
         if rows:
             best_rows = {}
@@ -231,11 +230,11 @@ class TorrentManager:
                     updated_at,
                 )
 
-            for row in rows:
+            for cache_media_id, row in rows:
                 info_hash = row["info_hash"]
                 current = best_rows.get(info_hash)
-                if current is None or row_priority(row) > row_priority(current):
-                    best_rows[info_hash] = row
+                if current is None or row_priority(row) > row_priority(current[1]):
+                    best_rows[info_hash] = (cache_media_id, row)
 
             rows = list(best_rows.values())
 
@@ -247,7 +246,7 @@ class TorrentManager:
             self.aliases,
         )
 
-        for row in rows:
+        for cache_media_id, row in rows:
             parsed_data = load_cached_parsed(row["parsed_json"])
             if parsed_data is None:
                 logger.warning(
@@ -303,7 +302,7 @@ class TorrentManager:
                 "parsed": parsed_data,
                 "updatedAt": row["updated_at"],
             }
-            if info_hash in primary_info_hashes:
+            if cache_media_id == self.media_only_id:
                 self.primary_cached = True
 
     def _append_cache_file_infos(self, file_infos: list[dict], torrent: dict):

--- a/comet/services/orchestration.py
+++ b/comet/services/orchestration.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 
+from pydantic import ValidationError
 from RTN import DefaultRanking, ParsedData
 
 from comet.core.execution import get_executor
@@ -9,7 +10,7 @@ from comet.core.models import CometSettingsModel, database, settings
 from comet.core.scrape import ScrapeContext
 from comet.scrapers.manager import scraper_manager
 from comet.scrapers.models import ScrapeRequest
-from comet.services.filtering import TitleMatcher, filter_worker
+from comet.services.filtering import TitleMatcher, filter_worker, parse_with_cache
 from comet.services.ranking import rank_worker
 from comet.services.torrent_manager import torrent_update_queue
 from comet.utils.languages import select_indexer_titles
@@ -255,8 +256,19 @@ class TorrentManager:
                 continue
             ensure_multi_language(parsed_data)
 
-            if parsed_data.parsed_title and not title_matcher.matches(
-                row["title"], parsed_data.parsed_title, parsed_data.year
+            torrent_title = row["title"]
+            if not isinstance(torrent_title, str) or not torrent_title:
+                continue
+            try:
+                parsed_title = parse_with_cache(torrent_title)
+            except ValidationError:
+                logger.warning(
+                    f"Skipping torrent cache row with invalid title: {row['info_hash']}"
+                )
+                continue
+
+            if not parsed_title.parsed_title or not title_matcher.matches(
+                torrent_title, parsed_title.parsed_title, parsed_title.year
             ):
                 continue
 

--- a/tests/test_cached_title_revalidation.py
+++ b/tests/test_cached_title_revalidation.py
@@ -51,6 +51,52 @@ class CachedTitleRevalidationTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(wrong_hash, manager.torrents)
         self.assertFalse(manager.primary_cached)
 
+    async def test_cached_row_with_wrong_year_is_rejected(self):
+        manager = self._manager()
+        wrong_year_hash = "e" * 40
+        wrong_year = self._row(
+            "Spider-Man.Homecoming.2019.2160p.BluRay.REMUX.HEVC.mkv",
+            wrong_year_hash,
+        )
+
+        with patch.object(manager, "_fetch_cached_rows", return_value=[wrong_year]):
+            await manager.get_cached_torrents()
+
+        self.assertNotIn(wrong_year_hash, manager.torrents)
+        self.assertFalse(manager.primary_cached)
+
+    async def test_cached_row_revalidates_legacy_parsed_data_from_raw_title(self):
+        manager = self._manager()
+        missing_title_hash = "c" * 40
+        row = self._row(
+            "Spider-Man.Homecoming.2017.2160p.BluRay.REMUX.HEVC.mkv",
+            missing_title_hash,
+        )
+        row["parsed_json"] = '{"raw_title":"Spider-Man.Homecoming.2017.mkv"}'
+
+        with patch.object(manager, "_fetch_cached_rows", return_value=[row]):
+            await manager.get_cached_torrents()
+
+        self.assertIn(missing_title_hash, manager.torrents)
+        self.assertTrue(manager.primary_cached)
+
+    async def test_cached_row_does_not_trust_persisted_parsed_title(self):
+        manager = self._manager()
+        inconsistent_hash = "d" * 40
+        row = self._row(
+            "Spider-Man.Into.the.Spider-Verse.2018.2160p.REMUX.HEVC.DV.mkv",
+            inconsistent_hash,
+        )
+        row["parsed_json"] = parse(
+            "Spider-Man.Homecoming.2017.2160p.BluRay.REMUX.HEVC.mkv"
+        ).model_dump_json()
+
+        with patch.object(manager, "_fetch_cached_rows", return_value=[row]):
+            await manager.get_cached_torrents()
+
+        self.assertNotIn(inconsistent_hash, manager.torrents)
+        self.assertFalse(manager.primary_cached)
+
     async def test_matching_cached_title_still_counts_as_primary_cache(self):
         manager = self._manager()
         right_hash = "b" * 40

--- a/tests/test_cached_title_revalidation.py
+++ b/tests/test_cached_title_revalidation.py
@@ -133,6 +133,10 @@ class CachedTitleRevalidationTests(unittest.IsolatedAsyncioTestCase):
             await manager.get_cached_torrents()
 
         self.assertIn(duplicate_hash, manager.torrents)
+        self.assertEqual(
+            manager.torrents[duplicate_hash]["updatedAt"],
+            secondary["updated_at"],
+        )
         self.assertFalse(manager.primary_cached)
 
 

--- a/tests/test_cached_title_revalidation.py
+++ b/tests/test_cached_title_revalidation.py
@@ -111,6 +111,30 @@ class CachedTitleRevalidationTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn(right_hash, manager.torrents)
         self.assertTrue(manager.primary_cached)
 
+    async def test_secondary_duplicate_does_not_count_as_primary_cache(self):
+        manager = self._manager()
+        manager.cache_media_ids = [manager.media_only_id, "kitsu:456"]
+        duplicate_hash = "f" * 40
+        primary = self._row(
+            "Spider-Man.Into.the.Spider-Verse.2018.2160p.REMUX.HEVC.DV.mkv",
+            duplicate_hash,
+        )
+        primary["updated_at"] = 1
+        secondary = self._row(
+            "Spider-Man.Homecoming.2017.2160p.BluRay.REMUX.HEVC.mkv",
+            duplicate_hash,
+        )
+        secondary["updated_at"] = 2
+
+        async def fetch_rows(media_id):
+            return [primary] if media_id == manager.media_only_id else [secondary]
+
+        with patch.object(manager, "_fetch_cached_rows", side_effect=fetch_rows):
+            await manager.get_cached_torrents()
+
+        self.assertIn(duplicate_hash, manager.torrents)
+        self.assertFalse(manager.primary_cached)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cached_title_revalidation.py
+++ b/tests/test_cached_title_revalidation.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch
+
+from RTN import parse
+
+from comet.services.orchestration import TorrentManager
+
+
+class CachedTitleRevalidationTests(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _row(title: str, info_hash: str) -> dict:
+        return {
+            "info_hash": info_hash,
+            "file_index": 0,
+            "title": title,
+            "seeders": 1,
+            "size": 1_000,
+            "tracker": "cache",
+            "sources_json": "[]",
+            "parsed_json": parse(title).model_dump_json(),
+            "episode": None,
+            "updated_at": 1,
+        }
+
+    @staticmethod
+    def _manager() -> TorrentManager:
+        return TorrentManager(
+            media_type="movie",
+            media_full_id="tt2250912",
+            media_only_id="tt2250912",
+            title="Spider-Man: Homecoming",
+            year=2017,
+            year_end=None,
+            season=None,
+            episode=None,
+            aliases={},
+            remove_adult_content=False,
+        )
+
+    async def test_mismatched_cached_title_is_rejected(self):
+        manager = self._manager()
+        wrong_hash = "a" * 40
+        wrong = self._row(
+            "Spider-Man.Into.the.Spider-Verse.2018.2160p.REMUX.HEVC.DV.mkv",
+            wrong_hash,
+        )
+
+        with patch.object(manager, "_fetch_cached_rows", return_value=[wrong]):
+            await manager.get_cached_torrents()
+
+        self.assertNotIn(wrong_hash, manager.torrents)
+        self.assertFalse(manager.primary_cached)
+
+    async def test_matching_cached_title_still_counts_as_primary_cache(self):
+        manager = self._manager()
+        right_hash = "b" * 40
+        right = self._row(
+            "Spider-Man.Homecoming.2017.2160p.BluRay.REMUX.HEVC.mkv",
+            right_hash,
+        )
+
+        with patch.object(manager, "_fetch_cached_rows", return_value=[right]):
+            await manager.get_cached_torrents()
+
+        self.assertIn(right_hash, manager.torrents)
+        self.assertTrue(manager.primary_cached)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -196,7 +196,7 @@ class TorrentOrchestrationTests(unittest.IsolatedAsyncioTestCase):
             media_type="movie",
             media_full_id="tt123",
             media_only_id="tt123",
-            title="Title",
+            title="Valid",
             year=2024,
             year_end=None,
             season=None,


### PR DESCRIPTION
## What changed

Cached torrent rows are now revalidated before they are returned:

- the raw cached release title is parsed with the same parser/cache used by live filtering;
- `TitleMatcher` checks the parsed title and release year against the requested media;
- persisted `parsed_json` is not trusted as the authority for title matching;
- invalid, empty, or mismatched cached titles are skipped;
- `primary_cached` is set only after an accepted row from the primary media ID, including when duplicate info hashes are deduplicated across cache IDs.

## Why

CometNet validates that an IMDb ID exists, but a propagated torrent's title can still be inconsistent with that ID. Because cached rows bypassed live title filtering, a release such as `Into the Spider-Verse` could be stored under `Spider-Man: Homecoming` and continue appearing in results.

## Tests

- `uv run pytest tests/test_cached_title_revalidation.py tests/test_orchestration.py tests/test_filtering.py` — 19 passed
- `uvx ruff check comet/services/filtering.py comet/services/orchestration.py tests/test_cached_title_revalidation.py tests/test_orchestration.py` — passed
- `uv run python -m compileall -q comet` — passed

The full suite cannot be collected on this Windows environment because `mediaflow_proxy` imports the Unix-only `fcntl` module in four existing streaming test modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cached torrent matching to reject results with mismatched titles, years, media types, or aliases.
  * Prevented duplicate results from being incorrectly treated as primary-cache matches.
  * Corrected primary-cache status so it is set only for valid results associated with the primary media item.
  * Excluded invalid or unparsable cached results while preserving compatibility with older cached metadata.

* **Tests**
  * Added coverage for matching titles, rejected mismatches, inconsistent metadata, and duplicate cache entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->