### PR TITLE
fix: accept HEAD requests on the playback endpoint

### DIFF
--- a/comet/api/endpoints/playback.py
+++ b/comet/api/endpoints/playback.py
@@ -181,8 +181,9 @@ async def _cache_download_link_safely(**kwargs) -> None:
         )
 
 
-@router.get(
+@router.api_route(
     "/{b64config}/playback/{hash}/{service_index}/{index}/{season}/{episode}",
+    methods=["GET", "HEAD"],
     tags=["Stremio"],
     summary="Playback Proxy",
     description="Proxies the playback request to the Debrid service or returns a cached link.",


### PR DESCRIPTION
### Problem

`/{b64config}/playback/...` is registered with `@router.get(...)`, so it answers **405 Method Not Allowed** to `HEAD`.

This is easy to miss because Starlette's `Route` auto-adds `HEAD` whenever `GET` is present, but FastAPI's `APIRoute` does not — it takes `methods` verbatim. So a plain `@router.get` route is GET-only.

Reported by a user on Stremio for Android TV (ExoPlayer), which probes the stream URL with `HEAD` before opening it. Desktop players don't, which is why this only shows up on some clients.

### Fix

Register the route with `api_route(..., methods=["GET", "HEAD"])`. One line plus the decorator swap; no handler changes.

The handler was already HEAD-ready:

- `request.method` is already forwarded to `custom_handle_stream_request`
- `mediaflow_proxy.handlers.handle_stream_request` has an explicit `HEAD` branch that closes the streamer and returns headers without a body
- `combined_background_tasks` already tolerates the `None` close-task that the HEAD branch produces, so the `active_connections` row is still released
- Starlette's `FileResponse` (status videos) and `RedirectResponse` both handle HEAD by sending headers only

### Verification

Against `v2.58.0`, on the playback route:

| | before | after |
|---|---|---|
| `HEAD` | 405 | 200, 0-byte body, `content-type: video/mp4` |
| `GET` | 200 | 200 (unchanged) |

### Note (not in this PR)

`/{b64config}/debrid-sync/{service_index}` is also handed to players as a stream URL and is likewise GET-only, so it 405s on HEAD too. I left it out because it is a side-effecting trigger — making it accept HEAD would mean a probe fires an account sync. Happy to follow up if you'd like it handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback requests now support both `GET` and `HEAD` methods.
  * Existing playback behavior and responses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->